### PR TITLE
Fix on NRE at OpenApiSecurityAttribute

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,7 @@ on:
     - main
     - dev
     - feature/*
+    - hotfix/*
 
 jobs:
   build_and_test:

--- a/docs/enable-open-api-endpoints.md
+++ b/docs/enable-open-api-endpoints.md
@@ -111,7 +111,7 @@ namespace MyOpenApiFunctionApp
         // Add these three attribute classes below
         [OpenApiOperation(operationId: "getName", tags: new[] { "name" }, Summary = "Gets the name", Description = "This gets the name.", Visibility = OpenApiVisibilityType.Important)]
         [OpenApiParameter(name: "name", In = ParameterLocation.Query, Required = true, Type = typeof(string), Summary = "The name", Description = "The name", Visibility = OpenApiVisibilityType.Important)]
-        [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, Name = "x-functions-key", In = OpenApiSecurityLocationType.Header)]
+        [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, Name = "code", In = OpenApiSecurityLocationType.Query)]
         [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "text/plain", bodyType: typeof(string), Summary = "The response", Description = "This returns the response")]
         // Add these three attribute classes above
 

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/DummyHttpTrigger.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/DummyHttpTrigger.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionAppV3Static
 
         [FunctionName(nameof(DummyHttpTrigger.UpdateDummies))]
         [OpenApiOperation(operationId: "updateDummies", tags: new[] { "dummy" }, Summary = "Updates a list of dummies", Description = "This updates a list of dummies.", Visibility = OpenApiVisibilityType.Advanced)]
-        [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, Name = "x-functions-key", In = OpenApiSecurityLocationType.Header)]
+        [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, Name = "code", In = OpenApiSecurityLocationType.Query)]
         [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(DummyListModel), Required = true, Description = "Dummy list model")]
         [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(List<DummyStringModel>), Summary = "Dummy response", Description = "This returns the dummy response")]
         public static async Task<IActionResult> UpdateDummies(

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Document.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Document.cs
@@ -146,12 +146,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
             this.OpenApiDocument.Paths = paths;
             this.OpenApiDocument.Components.Schemas = this._helper.GetOpenApiSchemas(methods, this._strategy, this._collection);
             this.OpenApiDocument.Components.SecuritySchemes = this._helper.GetOpenApiSecuritySchemes(methods, this._strategy);
-            this.OpenApiDocument.SecurityRequirements = this.OpenApiDocument
-                                                            .Paths
-                                                            .SelectMany(p => p.Value.Operations.SelectMany(q => q.Value.Security))
-                                                            .Where(p => !p.IsNullOrDefault())
-                                                            .Distinct(new OpenApiSecurityRequirementComparer())
-                                                            .ToList();
+            // this.OpenApiDocument.SecurityRequirements = this.OpenApiDocument
+            //                                                 .Paths
+            //                                                 .SelectMany(p => p.Value.Operations.SelectMany(q => q.Value.Security))
+            //                                                 .Where(p => !p.IsNullOrDefault())
+            //                                                 .Distinct(new OpenApiSecurityRequirementComparer())
+            //                                                 .ToList();
 
             return this;
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
             var attributes = element.GetCustomAttributes<OpenApiSecurityAttribute>(inherit: false);
             if (!attributes.Any())
             {
-                return null;
+                return new List<OpenApiSecurityRequirement>();
             }
 
             var requirements = new List<OpenApiSecurityRequirement>();


### PR DESCRIPTION
This fixes that `OpenApiSecurityAttribute` throwing `NullReferenceException`.

Instead of throwing NRE, it gracefully returns zero length list.
