### PR TITLE
Deprecated Attribute to Operation, Parameter and Schema

### DIFF
--- a/docs/openapi-core.md
+++ b/docs/openapi-core.md
@@ -135,6 +135,7 @@ public static async Task<IActionResult> GetSample(
 * `Summary`: is the summary of the operation.
 * `Description`: is the description of the operation.
 * `Visibility`: indicates how the operation is visible in Azure Logic Apps &ndash; `important`, `advanced` or `internal`. Default value is `undefined`.
+* `Deprecated`: indicates whether the operation is deprecated or not. Default is `false`.
 
 
 ### `OpenApiParameterAttribute` ###
@@ -162,6 +163,7 @@ public static async Task<IActionResult> GetSample(
 * `Explode`: indicates whether a query parameter is used multiple times (eg. `foo=bar1&foo=bar2&foo=bar3`) or not (eg. `foo=bar1,bar2,bar3`). Default value is `false`.
 * `Required`: indicates whether the parameter is required or not. Default value is `false`.
 * `Visibility`: indicates how the parameter is visible in Azure Logic Apps &ndash; `important`, `advanced` or `internal`. Default value is `undefined`.
+* `Deprecated`: indicates whether the parameter is deprecated or not. Default is `false`. If this is set to `true`, this parameter won't be showing up the UI and Open API document.
 
 
 ### `OpenApiSecurityAttribute` ###
@@ -253,6 +255,7 @@ public static async Task<IActionResult> PostSample(
 * `BodyType`: defines the type of the request payload.
 * `Description`: is the description of the request payload.
 * `Required`: indicates whether the request payload is mandatory or not.
+* `Deprecated`: indicates whether the request body is deprecated or not. Default is `false`. If this is set to `true`, this request body won't be showing up the UI and Open API document.
 
 
 ### `OpenApiResponseWithBodyAttribute` ###
@@ -276,6 +279,7 @@ public static async Task<IActionResult> PostSample(
 * `BodyType`: defines the type of the response payload.
 * `Summary`: is the summary of the response.
 * `Description`: is the description of the response.
+* `Deprecated`: indicates whether the response body is deprecated or not. Default is `false`. If this is set to `true`, this response body won't be showing up the UI and Open API document.
 
 
 ### `OpenApiResponseWithoutBodyAttribute` ###

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -68,6 +68,7 @@ public static async Task<IActionResult> RenderSwaggerUI(
 However, if you want to secure those endpoints, change their authorisation level to `AuthorizationLevel.Functions` and pass the API Key through either request header or querystring parameter.
 
 > **NOTE**: To change this authorisation level, you MUST install the `Microsoft.Azure.WebJobs.Extensions.OpenApi.Core` package, instead of `Microsoft.Azure.WebJobs.Extensions.OpenApi`, and copy those three files from the source codes to your application:
+> 
 > * `templates/OpenApiEndpoints/IOpenApiHttpTriggerContext.cs`
 > * `templates/OpenApiEndpoints/OpenApiHttpTrigger.cs`
 > * `templates/OpenApiEndpoints/OpenApiHttpTriggerContext.cs`

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/DummyHttpTrigger.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/DummyHttpTrigger.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static
         [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, Name = "code", In = OpenApiSecurityLocationType.Query)]
         [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(DummyListModel), Required = true, Description = "Dummy list model")]
         [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(List<DummyStringModel>), Summary = "Dummy response", Description = "This returns the dummy response")]
+        [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(DummyStringModel), Summary = "Dummy response", Description = "This returns the dummy response", Deprecated = true)]
         public static async Task<IActionResult> UpdateDummies(
             [HttpTrigger(AuthorizationLevel.Function, "PUT", Route = "dummies")] HttpRequest req,
             ILogger log)

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/DummyHttpTrigger.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/DummyHttpTrigger.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static
     public static class DummyHttpTrigger
     {
         [FunctionName(nameof(DummyHttpTrigger.GetDummies))]
-        [OpenApiOperation(operationId: "getDummies", tags: new[] { "dummy" }, Summary = "Gets the list of dummies", Description = "This gets the list of dummies.", Visibility = OpenApiVisibilityType.Important)]
+        [OpenApiOperation(operationId: "getDummies", tags: new[] { "dummy" }, Summary = "Gets the list of dummies", Description = "This gets the list of dummies.", Visibility = OpenApiVisibilityType.Important, Deprecated = true)]
         [OpenApiSecurity("basic_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Basic)]
         [OpenApiParameter(name: "name", In = ParameterLocation.Query, Required = true, Type = typeof(string), Summary = "Dummy name", Description = "Dummy name", Visibility = OpenApiVisibilityType.Important)]
         [OpenApiParameter(name: "onoff", In = ParameterLocation.Path, Required = true, Type = typeof(StringEnum), Summary = "Dummy switch", Description = "Dummy switch", Visibility = OpenApiVisibilityType.Important)]

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/DummyHttpTrigger.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/DummyHttpTrigger.cs
@@ -16,9 +16,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static
     public static class DummyHttpTrigger
     {
         [FunctionName(nameof(DummyHttpTrigger.GetDummies))]
-        [OpenApiOperation(operationId: "getDummies", tags: new[] { "dummy" }, Summary = "Gets the list of dummies", Description = "This gets the list of dummies.", Visibility = OpenApiVisibilityType.Important, Deprecated = true)]
+        [OpenApiOperation(operationId: "getDummies", tags: new[] { "dummy" }, Summary = "Gets the list of dummies", Description = "This gets the list of dummies.", Visibility = OpenApiVisibilityType.Important)]
         [OpenApiSecurity("basic_auth", SecuritySchemeType.Http, Scheme = OpenApiSecuritySchemeType.Basic)]
         [OpenApiParameter(name: "name", In = ParameterLocation.Query, Required = true, Type = typeof(string), Summary = "Dummy name", Description = "Dummy name", Visibility = OpenApiVisibilityType.Important)]
+        [OpenApiParameter(name: "switch", In = ParameterLocation.Query, Required = true, Type = typeof(bool), Summary = "Dummy switch", Description = "Dummy switch", Visibility = OpenApiVisibilityType.Important, Deprecated = true)]
         [OpenApiParameter(name: "onoff", In = ParameterLocation.Path, Required = true, Type = typeof(StringEnum), Summary = "Dummy switch", Description = "Dummy switch", Visibility = OpenApiVisibilityType.Important)]
         [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(List<DummyResponseModel>), Summary = "List of the dummy responses", Description = "This returns the list of dummy responses")]
         [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NotFound, Summary = "Name not found", Description = "Name parameter is not found")]
@@ -38,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static
         }
 
         [FunctionName(nameof(DummyHttpTrigger.AddDummy))]
-        [OpenApiOperation(operationId: "addDummy", tags: new[] { "dummy" }, Summary = "Adds a dummy", Description = "This adds a dummy.", Visibility = OpenApiVisibilityType.Advanced)]
+        [OpenApiOperation(operationId: "addDummy", tags: new[] { "dummy" }, Summary = "Adds a dummy", Description = "This adds a dummy.", Visibility = OpenApiVisibilityType.Advanced, Deprecated = true)]
         [OpenApiSecurity("openid_auth", SecuritySchemeType.OpenIdConnect, OpenIdConnectUrl = "https://example.com/.well-known/openid-configuration", OpenIdConnectScopes = "pets_read, pets_write, admin")]
         [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(DummyRequestModel), Required = true, Description = "Dummy request model")]
         [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(DummyResponseModel), Summary = "Dummy response", Description = "This returns the dummy response")]

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Attributes/OpenApiOperationAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Attributes/OpenApiOperationAttribute.cs
@@ -45,5 +45,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes
         /// Gets or sets the <see cref="OpenApiVisibilityType"/> value. Default is <see cref="OpenApiVisibilityType.Undefined"/>.
         /// </summary>
         public virtual OpenApiVisibilityType Visibility { get; set; } = OpenApiVisibilityType.Undefined;
+
+        /// <summary>
+        /// Gets or sets the value indicating whether the operation is deprecated or not.
+        /// </summary>
+        public virtual bool Deprecated { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Attributes/OpenApiParameterAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Attributes/OpenApiParameterAttribute.cs
@@ -66,5 +66,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes
         /// Gets or sets the <see cref="OpenApiVisibilityType"/> value. Default is <see cref="OpenApiVisibilityType.Undefined"/>.
         /// </summary>
         public virtual OpenApiVisibilityType Visibility { get; set; } = OpenApiVisibilityType.Undefined;
+
+        /// <summary>
+        /// Gets or sets the value indicating whether the parameter is deprecated or not.
+        /// </summary>
+        public virtual bool Deprecated { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Attributes/OpenApiRequestBodyAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Attributes/OpenApiRequestBodyAttribute.cs
@@ -22,5 +22,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes
         /// Gets or sets the value indicating whether the request body is required or not.
         /// </summary>
         public virtual bool Required { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating whether the request payload is deprecated or not.
+        /// </summary>
+        public virtual bool Deprecated { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Attributes/OpenApiResponseWithBodyAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Attributes/OpenApiResponseWithBodyAttribute.cs
@@ -31,5 +31,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes
         /// Gets or sets the summary.
         /// </summary>
         public virtual string Summary { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating whether the response payload is deprecated or not.
+        /// </summary>
+        public virtual bool Deprecated { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
@@ -163,6 +163,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
         public List<OpenApiParameter> GetOpenApiParameters(MethodInfo element, HttpTriggerAttribute trigger, NamingStrategy namingStrategy, VisitorCollection collection)
         {
             var parameters = element.GetCustomAttributes<OpenApiParameterAttribute>(inherit: false)
+                                    .Where(p => p.Deprecated == false)
                                     .Select(p => p.ToOpenApiParameter(namingStrategy, collection))
                                     .ToList();
 
@@ -185,7 +186,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
                 return null;
             }
 
-            var contents = attributes.ToDictionary(p => p.ContentType, p => p.ToOpenApiMediaType(namingStrategy, collection));
+            var contents = attributes.Where(p => p.Deprecated == false)
+                                     .ToDictionary(p => p.ContentType, p => p.ToOpenApiMediaType(namingStrategy, collection));
 
             if (contents.Any())
             {
@@ -216,10 +218,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
         public OpenApiResponses GetOpenApiResponses(MethodInfo element, NamingStrategy namingStrategy, VisitorCollection collection)
         {
             var responsesWithBody = element.GetCustomAttributes<OpenApiResponseWithBodyAttribute>(inherit: false)
-                                    .Select(p => new { StatusCode = p.StatusCode, Response = p.ToOpenApiResponse(namingStrategy) });
+                                           .Where(p => p.Deprecated == false)
+                                           .Select(p => new { StatusCode = p.StatusCode, Response = p.ToOpenApiResponse(namingStrategy) });
 
             var responsesWithoutBody = element.GetCustomAttributes<OpenApiResponseWithoutBodyAttribute>(inherit: false)
-                                       .Select(p => new { StatusCode = p.StatusCode, Response = p.ToOpenApiResponse(namingStrategy) });
+                                              .Select(p => new { StatusCode = p.StatusCode, Response = p.ToOpenApiResponse(namingStrategy) });
 
             var responses = responsesWithBody.Concat(responsesWithoutBody)
                                              .ToDictionary(p => ((int)p.StatusCode).ToString(), p => p.Response)

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
@@ -109,7 +109,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
                 OperationId = string.IsNullOrWhiteSpace(op.OperationId) ? $"{function.Name}_{verb}" : op.OperationId,
                 Tags = op.Tags.Select(p => new OpenApiTag() { Name = p }).ToList(),
                 Summary = op.Summary,
-                Description = op.Description
+                Description = op.Description,
+                Deprecated = op.Deprecated
             };
 
             if (op.Visibility != OpenApiVisibilityType.Undefined)

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiParameterAttributeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiParameterAttributeExtensions.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
                 Name = attribute.Name,
                 Description = attribute.Description,
                 Required = attribute.Required,
+                Deprecated = attribute.Deprecated,
                 In = attribute.In,
                 Schema = schema
             };

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiPayloadAttributeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiPayloadAttributeExtensions.cs
@@ -39,6 +39,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
             // Generate schema based on the type.
             var schema = collection.PayloadVisit(type, namingStrategy);
 
+            // Add deprecated attribute.
+            if (attribute is OpenApiRequestBodyAttribute)
+            {
+                schema.Deprecated = (attribute as OpenApiRequestBodyAttribute).Deprecated;
+            }
+            if (attribute is OpenApiResponseWithBodyAttribute)
+            {
+                schema.Deprecated = (attribute as OpenApiResponseWithBodyAttribute).Deprecated;
+            }
+
             // For array and dictionary object, the reference has already been added by the visitor.
             if (type.IsReferentialType() && !type.IsOpenApiNullable() && !type.IsOpenApiArray() && !type.IsOpenApiDictionary())
             {

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Attributes/OpenApiOperationAttributeTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Attributes/OpenApiOperationAttributeTests.cs
@@ -1,10 +1,9 @@
 using System.Linq;
 
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
-
 using FluentAssertions;
 
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Attributes
@@ -13,9 +12,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Attributes
     public class OpenApiOperationAttributeTests
     {
         [TestMethod]
-        public void Given_Null_Properties_Should_Return_Value()
+        public void Given_No_Parameters_When_Instantiated_Then_It_Should_Return_Value()
         {
-            var visibility = OpenApiVisibilityType.Undefined;
             var attribute = new OpenApiOperationAttribute();
 
             attribute.OperationId.Should().BeNullOrWhiteSpace();
@@ -23,24 +21,41 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Attributes
             attribute.Tags.Should().BeEmpty();
             attribute.Summary.Should().BeNullOrWhiteSpace();
             attribute.Description.Should().BeNullOrWhiteSpace();
-            attribute.Visibility.Should().Be(visibility);
+            attribute.Visibility.Should().Be(OpenApiVisibilityType.Undefined);
+            attribute.Deprecated.Should().BeFalse();
         }
 
-        [TestMethod]
-        public void Given_Value_Properties_Should_Return_Value()
+        [DataTestMethod]
+        [DataRow("lorem ipsum", "hello", "world")]
+        public void Given_Parameters_When_Instantiated_Then_It_Should_Return_Value(string opId, params string[] tags)
         {
-            var opId = "lorem ipsum";
-            var tag1 = "hello";
-            var tag2 = "world";
-            var visibility = OpenApiVisibilityType.Undefined;
-            var attribute = new OpenApiOperationAttribute(opId, tag1, tag2);
+            var attribute = new OpenApiOperationAttribute(opId, tags);
 
             attribute.OperationId.Should().BeEquivalentTo(opId);
-            attribute.Tags.First().Should().BeEquivalentTo(tag1);
-            attribute.Tags.Last().Should().BeEquivalentTo(tag2);
+            attribute.Tags.First().Should().BeEquivalentTo(tags[0]);
+            attribute.Tags.Last().Should().BeEquivalentTo(tags[1]);
             attribute.Summary.Should().BeNullOrWhiteSpace();
             attribute.Description.Should().BeNullOrWhiteSpace();
+            attribute.Visibility.Should().Be(OpenApiVisibilityType.Undefined);
+            attribute.Deprecated.Should().BeFalse();
+        }
+
+        [DataTestMethod]
+        [DataRow("Lorem Ipsum", "Hello World", OpenApiVisibilityType.Important, true)]
+        public void Given_Properties_When_Provided_Then_It_Should_Return_Value(string summary, string description, OpenApiVisibilityType visibility, bool deprecated)
+        {
+            var attribute = new OpenApiOperationAttribute("lorem ipsum", "hello", "world")
+            {
+                Summary = summary,
+                Description = description,
+                Visibility = visibility,
+                Deprecated = deprecated,
+            };
+
+            attribute.Summary.Should().Be(summary);
+            attribute.Description.Should().Be(description);
             attribute.Visibility.Should().Be(visibility);
+            attribute.Deprecated.Should().Be(deprecated);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Attributes/OpenApiParameterAttributeTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Attributes/OpenApiParameterAttributeTests.cs
@@ -1,10 +1,10 @@
 using System;
 
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
-
 using FluentAssertions;
 
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes;
 using Microsoft.OpenApi.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -14,17 +14,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Attributes
     public class OpenApiParameterAttributeTests
     {
         [TestMethod]
-        public void Given_Null_Constructor_Should_Throw_Exception()
+        public void Given_Null_When_Instantiated_It_Should_Throw_Exception()
         {
             Action action = () => new OpenApiParameterAttribute(null);
 
             action.Should().Throw<ArgumentNullException>();
         }
 
-        [TestMethod]
-        public void Given_Value_Property_Should_Return_Value()
+        [DataTestMethod]
+        [DataRow("Hello World")]
+        public void Given_Parameter_When_Instantiated_It_Should_Return_Value(string name)
         {
-            var name = "Hello World";
             var attribute = new OpenApiParameterAttribute(name);
 
             attribute.Name.Should().BeEquivalentTo(name);
@@ -33,9 +33,40 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Attributes
             attribute.Type.Should().Be<string>();
             attribute.In.Should().Be(ParameterLocation.Path);
             attribute.CollectionDelimiter.Should().Be(OpenApiParameterCollectionDelimiterType.Comma);
-            attribute.Explode.Should().Be(false);
-            attribute.Required.Should().Be(false);
+            attribute.Explode.Should().BeFalse();
+            attribute.Required.Should().BeFalse();
             attribute.Visibility.Should().Be(OpenApiVisibilityType.Undefined);
+            attribute.Deprecated.Should().BeFalse();
+        }
+
+        [DataTestMethod]
+        [DataRow("Hello World", "Lorem Ipsum", typeof(FakeModel), ParameterLocation.Header, OpenApiParameterCollectionDelimiterType.Pipe, true, true, OpenApiVisibilityType.Important, true)]
+        public void Given_Properties_When_Instantiated_It_Should_Return_Value(
+            string summary, string description, Type type, ParameterLocation @in,
+            OpenApiParameterCollectionDelimiterType delimiter, bool explode, bool required, OpenApiVisibilityType visibility, bool deprecated)
+        {
+            var attribute = new OpenApiParameterAttribute("Name")
+            {
+                Summary = summary,
+                Description = description,
+                Type = type,
+                In = @in,
+                CollectionDelimiter = delimiter,
+                Explode = explode,
+                Required = required,
+                Visibility = visibility,
+                Deprecated = deprecated,
+            };
+
+            attribute.Summary.Should().Be(summary);
+            attribute.Description.Should().Be(description);
+            attribute.Type.Should().Be(type);
+            attribute.In.Should().Be(@in);
+            attribute.CollectionDelimiter.Should().Be(delimiter);
+            attribute.Explode.Should().Be(explode);
+            attribute.Required.Should().Be(required);
+            attribute.Visibility.Should().Be(visibility);
+            attribute.Deprecated.Should().Be(deprecated);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Attributes/OpenApiRequestBodyAttributeTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Attributes/OpenApiRequestBodyAttributeTests.cs
@@ -1,9 +1,8 @@
 using System;
 
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
-
 using FluentAssertions;
 
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Attributes
@@ -12,7 +11,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Attributes
     public class OpenApiRequestBodyAttributeTests
     {
         [TestMethod]
-        public void Given_Null_Constructor_Should_Throw_Exception()
+        public void Given_Null_When_Instantiated_Then_It_Should_Throw_Exception()
         {
             Action action = () => new OpenApiRequestBodyAttribute(null, null);
             action.Should().Throw<ArgumentNullException>();
@@ -21,17 +20,35 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Attributes
             action.Should().Throw<ArgumentNullException>();
         }
 
-        [TestMethod]
-        public void Given_Value_Property_Should_Return_Value()
+        [DataTestMethod]
+        [DataRow("Hello World", typeof(object))]
+        public void Given_Parameters_When_Instantiated_It_Should_Return_Value(string contentType, Type bodyType)
         {
-            var contentType = "Hello World";
-            var bodyType = typeof(object);
             var attribute = new OpenApiRequestBodyAttribute(contentType, bodyType);
 
             attribute.ContentType.Should().BeEquivalentTo(contentType);
             attribute.BodyType.Should().Be(bodyType);
-            attribute.Description.Should().BeNullOrWhiteSpace();
-            attribute.Required.Should().Be(false);
+        }
+
+        [DataTestMethod]
+        [DataRow("Lorem Ipsum", true, true)]
+        [DataRow("Lorem Ipsum", true, false)]
+        [DataRow("Lorem Ipsum", false, true)]
+        [DataRow("Lorem Ipsum", false, false)]
+        public void Given_Properties_When_Instantiated_It_Should_Return_Value(string description, bool required, bool deprecated)
+        {
+            var contentType = "Hello World";
+            var bodyType = typeof(object);
+            var attribute = new OpenApiRequestBodyAttribute(contentType, bodyType)
+            {
+                Description = description,
+                Required = required,
+                Deprecated = deprecated,
+            };
+
+            attribute.Description.Should().Be(description);
+            attribute.Required.Should().Be(required);
+            attribute.Deprecated.Should().Be(deprecated);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Attributes/OpenApiResponseWithBodyAttributeTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Attributes/OpenApiResponseWithBodyAttributeTests.cs
@@ -1,10 +1,9 @@
 using System;
 using System.Net;
 
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
-
 using FluentAssertions;
 
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Attributes
@@ -13,7 +12,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Attributes
     public class OpenApiResponseWithBodyAttributeTests
     {
         [TestMethod]
-        public void Given_Null_Constructor_Should_Throw_Exception()
+        public void Given_Null_When_Instantiated_Then_It_Should_Throw_Exception()
         {
             var statusCode = HttpStatusCode.OK;
 
@@ -24,19 +23,35 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Attributes
             action.Should().Throw<ArgumentNullException>();
         }
 
-        [TestMethod]
-        public void Given_Value_Property_Should_Return_Value()
+        [DataTestMethod]
+        [DataRow(HttpStatusCode.OK, "application/json", typeof(object))]
+        public void Given_Parameters_When_Instantiated_Then_It_Should_Return_Value(HttpStatusCode statusCode, string contentType, Type bodyType)
         {
-            var statusCode = HttpStatusCode.OK;
-            var contentType = "Hello World";
-            var bodyType = typeof(object);
             var attribute = new OpenApiResponseWithBodyAttribute(statusCode, contentType, bodyType);
 
             attribute.StatusCode.Should().Be(statusCode);
             attribute.ContentType.Should().BeEquivalentTo(contentType);
             attribute.BodyType.Should().Be(bodyType);
-            attribute.Summary.Should().BeNullOrWhiteSpace();
-            attribute.Description.Should().BeNullOrWhiteSpace();
+        }
+
+        [DataTestMethod]
+        [DataRow("Lorem Ipsum", "Hello World", true)]
+        [DataRow("Lorem Ipsum", "Hello World", false)]
+        public void Given_Properties_When_Instantiated_Then_It_Should_Return_Value(string summary, string description, bool deprecated)
+        {
+            var statusCode = HttpStatusCode.OK;
+            var contentType = "application/json";
+            var bodyType = typeof(object);
+            var attribute = new OpenApiResponseWithBodyAttribute(statusCode, contentType, bodyType)
+            {
+                Summary = summary,
+                Description = description,
+                Deprecated = deprecated,
+            };
+
+            attribute.Summary.Should().Be(summary);
+            attribute.Description.Should().Be(description);
+            attribute.Deprecated.Should().Be(deprecated);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/OpenApiPayloadAttributeExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/OpenApiPayloadAttributeExtensionsTests.cs
@@ -2,12 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 
+using FluentAssertions;
+
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes;
-
-using FluentAssertions;
-
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Newtonsoft.Json.Serialization;
@@ -41,6 +40,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
             var result = OpenApiPayloadAttributeExtensions.ToOpenApiMediaType(attribute, namingStrategy);
 
             result.Schema.Type.Should().Be(expected);
+            result.Schema.Deprecated.Should().BeFalse();
+        }
+
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void Given_OpenApiRequestBodyAttribute_With_Deprecated_When_ToOpenApiMediaType_Invoked_Then_It_Should_Return_Result(bool deprecated)
+        {
+            var contentType = "application/json";
+            var bodyType = typeof(object);
+            var attribute = new OpenApiRequestBodyAttribute(contentType, bodyType)
+            {
+                Required = true,
+                Description = "Dummy request model",
+                Deprecated = deprecated,
+            };
+            var namingStrategy = new CamelCaseNamingStrategy();
+
+            var result = OpenApiPayloadAttributeExtensions.ToOpenApiMediaType(attribute, namingStrategy);
+
+            result.Schema.Deprecated.Should().Be(deprecated);
         }
 
         [DataTestMethod]
@@ -58,6 +78,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
             var result = OpenApiPayloadAttributeExtensions.ToOpenApiMediaType(attribute, namingStrategy);
 
             result.Schema.Type.Should().Be(expected);
+            result.Schema.Deprecated.Should().BeFalse();
             if (items)
             {
                 result.Schema.Items.Should().NotBeNull();
@@ -77,6 +98,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
             {
                 result.Schema.AdditionalProperties.Should().BeNull();
             }
+        }
+
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void Given_OpenApiResponseWithBodyAttribute_With_Deprecated_When_ToOpenApiMediaType_Invoked_Then_It_Should_Return_Result(bool deprecated)
+        {
+            var statusCode = HttpStatusCode.OK;
+            var contentType = "application/json";
+            var bodyType = typeof(object);
+            var attribute = new OpenApiResponseWithBodyAttribute(statusCode, contentType, bodyType)
+            {
+                Deprecated = deprecated,
+            };
+            var namingStrategy = new CamelCaseNamingStrategy();
+
+            var result = OpenApiPayloadAttributeExtensions.ToOpenApiMediaType(attribute, namingStrategy);
+
+            result.Schema.Deprecated.Should().Be(deprecated);
         }
     }
 }


### PR DESCRIPTION
PR for #27 

This is to implement the `deprecated` attribute on the `Operation`, `Parameter` and `Schema`  objects so that the UI page and document reflect them.

* If the `Deprecated` property value is set to `true` on `OpenApiParameterAttribute`, `OpenApiRequestBodyAttribute` and `OpenApiResponseWithBodyAttribute`, they are not showing up on both UI and document.
* If the `Deprecated` property value is set to `true` on `OpenApiOperationAttribute`, the specified operation is greyed out so that it gives the visual indication to devs.
