### PR TITLE
Extra Base URLs for Open API v3

### DIFF
--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V1Proxy/Configurations/OpenApiConfigurationOptions.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V1Proxy/Configurations/OpenApiConfigurationOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.OpenApi.Models;
@@ -25,5 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V1Proxy.Configu
                 Url = new Uri("http://opensource.org/licenses/MIT"),
             }
         };
+
+        public List<OpenApiServer> Servers { get; set; } = new List<OpenApiServer>();
     }
 }

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC/Configurations/OpenApiConfigurationOptions.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC/Configurations/OpenApiConfigurationOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.OpenApi.Models;
@@ -25,5 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC.Configura
                 Url = new Uri("http://opensource.org/licenses/MIT"),
             }
         };
+
+        public List<OpenApiServer> Servers { get; set; } = new List<OpenApiServer>();
     }
 }

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static/Configurations/OpenApiConfigurationOptions.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static/Configurations/OpenApiConfigurationOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.OpenApi.Models;
@@ -25,5 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static.Config
                 Url = new Uri("http://opensource.org/licenses/MIT"),
             }
         };
+
+        public List<OpenApiServer> Servers { get; set; } = new List<OpenApiServer>();
     }
 }

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/Configurations/OpenApiConfigurationOptions.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/Configurations/OpenApiConfigurationOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.OpenApi.Models;
@@ -25,5 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC.Configura
                 Url = new Uri("http://opensource.org/licenses/MIT"),
             }
         };
+
+        public List<OpenApiServer> Servers { get; set; } = new List<OpenApiServer>();
     }
 }

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/Configurations/OpenApiConfigurationOptions.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/Configurations/OpenApiConfigurationOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.OpenApi.Models;
@@ -24,6 +25,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static.Config
                 Name = "MIT",
                 Url = new Uri("http://opensource.org/licenses/MIT"),
             }
+        };
+
+        public List<OpenApiServer> Servers { get; set; } = new List<OpenApiServer>()
+        {
+            new OpenApiServer() { Url = "https://contoso.com/api/" },
+            new OpenApiServer() { Url = "https://fabrikam.com/api/" },
         };
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/IOpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/IOpenApiConfigurationOptions.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
@@ -11,5 +13,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
         /// Gets or sets the <see cref="OpenApiInfo"/> instance.
         /// </summary>
         OpenApiInfo Info { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of <see cref="OpenApiServer"/> instances.
+        /// </summary>
+        List<OpenApiServer> Servers { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiAppSettingsBase.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiAppSettingsBase.cs
@@ -20,8 +20,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
         {
             var basePath = this.GetBasePath();
             var host = HostJsonResolver.Resolve(this.Config, basePath);
+            var options = OpenApiConfigurationResolver.Resolve(Assembly.GetExecutingAssembly());
 
-            this.OpenApiInfo = OpenApiInfoResolver.Resolve(Assembly.GetExecutingAssembly());
+            this.OpenApiInfo = options.Info;
             this.SwaggerAuthKey = this.Config.GetValue<string>("OpenApi:ApiKey");
 
             this.HttpSettings = host.GetHttpSettings();

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiSettings.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiSettings.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
@@ -13,5 +15,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
             Version = "1.0.0",
             Title = "Azure Functions Open API Extension",
         };
+
+        /// <inheritdoc />
+        public List<OpenApiServer> Servers { get; set; } = new List<OpenApiServer>();
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/IDocument.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/IDocument.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors;
 using Microsoft.OpenApi;
 using Microsoft.OpenApi.Models;
@@ -38,8 +39,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions
         /// </summary>
         /// <param name="req"><see cref="HttpRequest"/> instance.</param>
         /// <param name="routePrefix">Route prefix value.</param>
+        /// <param name="options"><see cref="IOpenApiConfigurationOptions"/> instance.</param>
         /// <returns><see cref="IDocument"/> instance.</returns>
-        IDocument AddServer(HttpRequest req, string routePrefix);
+        IDocument AddServer(HttpRequest req, string routePrefix, IOpenApiConfigurationOptions options = null);
 
         /// <summary>
         /// Adds the naming strategy.

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/ISwaggerUI.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/ISwaggerUI.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions
@@ -22,8 +23,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions
         /// </summary>
         /// <param name="req"><see cref="HttpRequest"/> instance.</param>
         /// <param name="routePrefix">Route prefix value.</param>
+        /// <param name="options"><see cref="IOpenApiConfigurationOptions"/> instance.</param>
         /// <returns><see cref="IDocument"/> instance.</returns>
-        ISwaggerUI AddServer(HttpRequest req, string routePrefix);
+        ISwaggerUI AddServer(HttpRequest req, string routePrefix, IOpenApiConfigurationOptions options = null);
 
         /// <summary>
         /// Builds Open API document.

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Resolvers/OpenApiConfigurationResolver.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Resolvers/OpenApiConfigurationResolver.cs
@@ -9,16 +9,16 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Resolvers
 {
     /// <summary>
-    /// This represents the resolver entity for <see cref="OpenApiInfo"/> from one of host.json, openapisettings.json and environment variables.
+    /// This represents the resolver entity for <see cref="OpenApiServer"/>.
     /// </summary>
-    public static class OpenApiInfoResolver
+    public static class OpenApiConfigurationResolver
     {
         /// <summary>
-        /// Gets the <see cref="OpenApiInfo"/> instance from one of host.json, openapisettings.json and environment variables.
+        /// Gets the <see cref="IOpenApiConfigurationOptions"/> instance from the given assembly.
         /// </summary>
         /// <param name="assembly">The executing assembly instance.</param>
-        /// <returns>Returns <see cref="OpenApiInfo"/> instance resolved.</returns>
-        public static OpenApiInfo Resolve(Assembly assembly)
+        /// <returns>Returns the <see cref="IOpenApiConfigurationOptions"/> instance resolved.</returns>
+        public static IOpenApiConfigurationOptions Resolve(Assembly assembly)
         {
             var type = assembly.GetTypes()
                                .SingleOrDefault(p => p.GetInterface("IOpenApiConfigurationOptions", ignoreCase: true).IsNullOrDefault() == false);
@@ -26,12 +26,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Resolvers
             {
                 var settings = new OpenApiSettings();
 
-                return settings.Info;
+                return settings;
             }
 
             var options = Activator.CreateInstance(type);
 
-            return (options as IOpenApiConfigurationOptions).Info;
+            return options as IOpenApiConfigurationOptions;
         }
     }
 }

--- a/templates/OpenApiEndpoints/IOpenApiHttpTriggerContext.cs
+++ b/templates/OpenApiEndpoints/IOpenApiHttpTriggerContext.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Reflection;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
@@ -18,9 +19,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
     public interface IOpenApiHttpTriggerContext
     {
         /// <summary>
-        /// Gets the <see cref="OpenApiInfo"/> instance.
+        /// Gets the <see cref="IOpenApiConfigurationOptions"/> instance.
         /// </summary>
-        OpenApiInfo OpenApiInfo { get; }
+        IOpenApiConfigurationOptions OpenApiConfiguration { get; }
 
         /// <summary>
         /// Gets the <see cref="HttpSettings"/> instance.

--- a/templates/OpenApiEndpoints/OpenApiHttpTrigger.cs
+++ b/templates/OpenApiEndpoints/OpenApiHttpTrigger.cs
@@ -48,8 +48,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
 
             var result = await context.Document
                                       .InitialiseDocument()
-                                      .AddMetadata(context.OpenApiInfo)
-                                      .AddServer(req, context.HttpSettings.RoutePrefix)
+                                      .AddMetadata(context.OpenApiConfiguration.Info)
+                                      .AddServer(req, context.HttpSettings.RoutePrefix, context.OpenApiConfiguration)
                                       .AddNamingStrategy(context.NamingStrategy)
                                       .AddVisitors(context.GetVisitorCollection())
                                       .Build(context.GetExecutingAssembly())
@@ -86,8 +86,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
 
             var result = await context.Document
                                       .InitialiseDocument()
-                                      .AddMetadata(context.OpenApiInfo)
-                                      .AddServer(req, context.HttpSettings.RoutePrefix)
+                                      .AddMetadata(context.OpenApiConfiguration.Info)
+                                      .AddServer(req, context.HttpSettings.RoutePrefix, context.OpenApiConfiguration)
                                       .AddNamingStrategy(context.NamingStrategy)
                                       .AddVisitors(context.GetVisitorCollection())
                                       .Build(context.GetExecutingAssembly())
@@ -119,8 +119,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
             log.LogInformation($"SwaggerUI page was requested.");
 
             var result = await context.SwaggerUI
-                                      .AddMetadata(context.OpenApiInfo)
-                                      .AddServer(req, context.HttpSettings.RoutePrefix)
+                                      .AddMetadata(context.OpenApiConfiguration.Info)
+                                      .AddServer(req, context.HttpSettings.RoutePrefix, context.OpenApiConfiguration)
                                       .BuildAsync()
                                       .RenderAsync("swagger.json", context.GetSwaggerAuthKey())
                                       .ConfigureAwait(false);

--- a/templates/OpenApiEndpoints/OpenApiHttpTriggerContext.cs
+++ b/templates/OpenApiEndpoints/OpenApiHttpTriggerContext.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
@@ -35,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
         {
             var host = HostJsonResolver.Resolve();
 
-            this.OpenApiInfo = OpenApiInfoResolver.Resolve(this.GetExecutingAssembly());
+            this.OpenApiConfiguration = OpenApiConfigurationResolver.Resolve(this.GetExecutingAssembly());
             this.HttpSettings = host.GetHttpSettings();
 
             var filter = new RouteConstraintFilter();
@@ -47,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
         }
 
         /// <inheritdoc />
-        public virtual OpenApiInfo OpenApiInfo { get; }
+        public virtual IOpenApiConfigurationOptions OpenApiConfiguration { get; }
 
         /// <inheritdoc />
         public virtual HttpSettings HttpSettings { get; }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Resolvers/OpenApiConfigurationResolverTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Resolvers/OpenApiConfigurationResolverTests.cs
@@ -2,21 +2,21 @@ using System.Reflection;
 
 using FluentAssertions;
 
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Resolvers;
-using Microsoft.OpenApi.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Resolvers
 {
     [TestClass]
-    public class OpenApiInfoResolverTests
+    public class OpenApiConfigurationResolverTests
     {
         [TestMethod]
         public void Given_Type_Then_It_Should_Have_Methods()
         {
-            typeof(OpenApiInfoResolver)
+            typeof(OpenApiConfigurationResolver)
                 .Should().HaveMethod("Resolve", new[] { typeof(Assembly) })
-                .Which.Should().Return<OpenApiInfo>();
+                .Which.Should().Return<IOpenApiConfigurationOptions>();
         }
     }
 }


### PR DESCRIPTION
This is related to #35 

This adds a feature that adds extra base URLs as servers, which is applicable to v3 spec. It doesn't change the v2 spec (Swagger).
