### PR TITLE
GetSwaggerAuthKey should not return nullable string

### DIFF
--- a/templates/OpenApiEndpoints/OpenApiHttpTriggerContext.cs
+++ b/templates/OpenApiEndpoints/OpenApiHttpTriggerContext.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
         {
             var value = Environment.GetEnvironmentVariable(key);
 
-            return value;
+            return value ?? string.Empty;
         }
     }
 }


### PR DESCRIPTION
Fixes #48

`GetSwaggerAuthKey` should return a `string`, but it returns a `string?`
This can cause warnings or errors when these files are included in a project with nullability enabled.

It's fixed by returning an empty string when the value is null.

This should not cause any different behaviour, because where the authKey is used, there is a `if (!string.IsNullOrWhiteSpace(authKey))`, so `null` and `string.Empty` are treated the same:
https://github.com/Azure/azure-functions-openapi-extension/blob/main/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/SwaggerUI.cs#L118