### PR TITLE
Add visitors for unsigned integer types

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/UInt16TypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/UInt16TypeVisitor.cs
@@ -1,9 +1,12 @@
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
-using Microsoft.OpenApi.Models;
-using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
+
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+
+using Microsoft.OpenApi.Models;
+
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
 {

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/UInt16TypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/UInt16TypeVisitor.cs
@@ -1,0 +1,64 @@
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+using Microsoft.OpenApi.Models;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
+{
+    /// <summary>
+    /// This represents the type visitor for <see cref="ushort"/>.
+    /// </summary>
+    public class UInt16TypeVisitor : TypeVisitor
+    {
+        /// <inheritdoc />
+        public UInt16TypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
+        public override bool IsVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type, TypeCode.UInt16) &&
+                              !type.IsUnflaggedEnumType();
+
+            return isVisitable;
+        }
+
+        /// <inheritdoc />
+        public override void Visit(IAcceptor acceptor, KeyValuePair<string, Type> type, NamingStrategy namingStrategy, params Attribute[] attributes)
+        {
+            this.Visit(acceptor, name: type.Key, title: null, dataType: "integer", dataFormat: null, attributes: attributes);
+        }
+
+        /// <inheritdoc />
+        public override bool IsParameterVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type);
+
+            return isVisitable;
+        }
+
+        /// <inheritdoc />
+        public override OpenApiSchema ParameterVisit(Type type, NamingStrategy namingStrategy)
+        {
+            return this.ParameterVisit(dataType: "integer", dataFormat: null);
+        }
+
+        /// <inheritdoc />
+        public override bool IsPayloadVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type);
+
+            return isVisitable;
+        }
+
+        /// <inheritdoc />
+        public override OpenApiSchema PayloadVisit(Type type, NamingStrategy namingStrategy)
+        {
+            return this.PayloadVisit(dataType: "integer", dataFormat: null);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/UInt32TypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/UInt32TypeVisitor.cs
@@ -1,9 +1,12 @@
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
-using Microsoft.OpenApi.Models;
-using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
+
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+
+using Microsoft.OpenApi.Models;
+
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
 {

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/UInt32TypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/UInt32TypeVisitor.cs
@@ -1,0 +1,64 @@
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+using Microsoft.OpenApi.Models;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
+{
+    /// <summary>
+    /// This represents the type visitor for <see cref="uint"/>.
+    /// </summary>
+    public class UInt32TypeVisitor : TypeVisitor
+    {
+        /// <inheritdoc />
+        public UInt32TypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
+        public override bool IsVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type, TypeCode.UInt32) &&
+                              !type.IsUnflaggedEnumType();
+
+            return isVisitable;
+        }
+
+        /// <inheritdoc />
+        public override void Visit(IAcceptor acceptor, KeyValuePair<string, Type> type, NamingStrategy namingStrategy, params Attribute[] attributes)
+        {
+            this.Visit(acceptor, name: type.Key, title: null, dataType: "integer", dataFormat: null, attributes: attributes);
+        }
+
+        /// <inheritdoc />
+        public override bool IsParameterVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type);
+
+            return isVisitable;
+        }
+
+        /// <inheritdoc />
+        public override OpenApiSchema ParameterVisit(Type type, NamingStrategy namingStrategy)
+        {
+            return this.ParameterVisit(dataType: "integer", dataFormat: null);
+        }
+
+        /// <inheritdoc />
+        public override bool IsPayloadVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type);
+
+            return isVisitable;
+        }
+
+        /// <inheritdoc />
+        public override OpenApiSchema PayloadVisit(Type type, NamingStrategy namingStrategy)
+        {
+            return this.PayloadVisit(dataType: "integer", dataFormat: null);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/UInt64TypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/UInt64TypeVisitor.cs
@@ -1,9 +1,12 @@
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
-using Microsoft.OpenApi.Models;
-using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
+
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+
+using Microsoft.OpenApi.Models;
+
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
 {

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/UInt64TypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/UInt64TypeVisitor.cs
@@ -1,0 +1,64 @@
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+using Microsoft.OpenApi.Models;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
+{
+    /// <summary>
+    /// This represents the type visitor for <see cref="ulong"/>.
+    /// </summary>
+    public class UInt64TypeVisitor : TypeVisitor
+    {
+        /// <inheritdoc />
+        public UInt64TypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
+        public override bool IsVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type, TypeCode.UInt64) &&
+                              !type.IsUnflaggedEnumType();
+
+            return isVisitable;
+        }
+
+        /// <inheritdoc />
+        public override void Visit(IAcceptor acceptor, KeyValuePair<string, Type> type, NamingStrategy namingStrategy, params Attribute[] attributes)
+        {
+            this.Visit(acceptor, name: type.Key, title: null, dataType: "integer", dataFormat: null, attributes: attributes);
+        }
+
+        /// <inheritdoc />
+        public override bool IsParameterVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type);
+
+            return isVisitable;
+        }
+
+        /// <inheritdoc />
+        public override OpenApiSchema ParameterVisit(Type type, NamingStrategy namingStrategy)
+        {
+            return this.ParameterVisit(dataType: "integer", dataFormat: null);
+        }
+
+        /// <inheritdoc />
+        public override bool IsPayloadVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type);
+
+            return isVisitable;
+        }
+
+        /// <inheritdoc />
+        public override OpenApiSchema PayloadVisit(Type type, NamingStrategy namingStrategy)
+        {
+            return this.PayloadVisit(dataType: "integer", dataFormat: null);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt16TypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt16TypeVisitorTests.cs
@@ -1,14 +1,18 @@
-using FluentAssertions;
+using System;
+using System.Collections.Generic;
+
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors;
+
+using FluentAssertions;
+
 using Microsoft.OpenApi.Any;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Newtonsoft.Json.Serialization;
-using System;
-using System.Collections.Generic;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 {

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt16TypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt16TypeVisitorTests.cs
@@ -1,0 +1,137 @@
+using FluentAssertions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors;
+using Microsoft.OpenApi.Any;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
+{
+    [TestClass]
+    public class UInt16TypeVisitorTests
+    {
+        private VisitorCollection _visitorCollection;
+        private IVisitor _visitor;
+        private NamingStrategy _strategy;
+
+        [TestInitialize]
+        public void Init()
+        {
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new UInt16TypeVisitor(this._visitorCollection);
+            this._strategy = new CamelCaseNamingStrategy();
+        }
+
+        [DataTestMethod]
+        [DataRow(typeof(ushort), false)]
+        public void Given_Type_When_IsNavigatable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
+        {
+            var result = this._visitor.IsNavigatable(type);
+
+            result.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(typeof(ushort), true)]
+        [DataRow(typeof(short), false)]
+        [DataRow(typeof(string), false)]
+        public void Given_Type_When_IsVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
+        {
+            var result = this._visitor.IsVisitable(type);
+
+            result.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(typeof(ushort), true)]
+        [DataRow(typeof(short), false)]
+        [DataRow(typeof(string), false)]
+        public void Given_Type_When_IsParameterVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
+        {
+            var result = this._visitor.IsParameterVisitable(type);
+
+            result.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(typeof(ushort), true)]
+        [DataRow(typeof(short), false)]
+        [DataRow(typeof(string), false)]
+        public void Given_Type_When_IsPayloadVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
+        {
+            var result = this._visitor.IsPayloadVisitable(type);
+
+            result.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow("integer", null)]
+        public void Given_Type_When_Visit_Invoked_Then_It_Should_Return_Result(string dataType, string dataFormat)
+        {
+            var name = "hello";
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(ushort));
+
+            this._visitor.Visit(acceptor, type, this._strategy);
+
+            acceptor.Schemas.Should().ContainKey(name);
+            acceptor.Schemas[name].Type.Should().Be(dataType);
+            acceptor.Schemas[name].Format.Should().Be(dataFormat);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", "lorem ipsum")]
+        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(ushort));
+            var attribute = new OpenApiPropertyDescriptionAttribute(description);
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", OpenApiVisibilityType.Advanced)]
+        [DataRow("hello", OpenApiVisibilityType.Important)]
+        [DataRow("hello", OpenApiVisibilityType.Internal)]
+        public void Given_OpenApiSchemaVisibilityAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, OpenApiVisibilityType visibility)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(ushort));
+            var attribute = new OpenApiSchemaVisibilityAttribute(visibility);
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
+            acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+        }
+
+        [DataTestMethod]
+        [DataRow("integer", null)]
+        public void Given_Type_When_ParameterVisit_Invoked_Then_It_Should_Return_Result(string dataType, string dataFormat)
+        {
+            var result = this._visitor.ParameterVisit(typeof(ushort), this._strategy);
+
+            result.Type.Should().Be(dataType);
+            result.Format.Should().Be(dataFormat);
+        }
+
+        [DataTestMethod]
+        [DataRow("integer", null)]
+        public void Given_Type_When_PayloadVisit_Invoked_Then_It_Should_Return_Result(string dataType, string dataFormat)
+        {
+            var result = this._visitor.PayloadVisit(typeof(ushort), this._strategy);
+
+            result.Type.Should().Be(dataType);
+            result.Format.Should().Be(dataFormat);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt32TypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt32TypeVisitorTests.cs
@@ -1,0 +1,137 @@
+using FluentAssertions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors;
+using Microsoft.OpenApi.Any;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
+{
+    [TestClass]
+    public class UInt32TypeVisitorTests
+    {
+        private VisitorCollection _visitorCollection;
+        private IVisitor _visitor;
+        private NamingStrategy _strategy;
+
+        [TestInitialize]
+        public void Init()
+        {
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new UInt32TypeVisitor(this._visitorCollection);
+            this._strategy = new CamelCaseNamingStrategy();
+        }
+
+        [DataTestMethod]
+        [DataRow(typeof(uint), false)]
+        public void Given_Type_When_IsNavigatable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
+        {
+            var result = this._visitor.IsNavigatable(type);
+
+            result.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(typeof(uint), true)]
+        [DataRow(typeof(int), false)]
+        [DataRow(typeof(string), false)]
+        public void Given_Type_When_IsVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
+        {
+            var result = this._visitor.IsVisitable(type);
+
+            result.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(typeof(uint), true)]
+        [DataRow(typeof(int), false)]
+        [DataRow(typeof(string), false)]
+        public void Given_Type_When_IsParameterVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
+        {
+            var result = this._visitor.IsParameterVisitable(type);
+
+            result.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(typeof(uint), true)]
+        [DataRow(typeof(int), false)]
+        [DataRow(typeof(string), false)]
+        public void Given_Type_When_IsPayloadVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
+        {
+            var result = this._visitor.IsPayloadVisitable(type);
+
+            result.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow("integer", null)]
+        public void Given_Type_When_Visit_Invoked_Then_It_Should_Return_Result(string dataType, string dataFormat)
+        {
+            var name = "hello";
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(uint));
+
+            this._visitor.Visit(acceptor, type, this._strategy);
+
+            acceptor.Schemas.Should().ContainKey(name);
+            acceptor.Schemas[name].Type.Should().Be(dataType);
+            acceptor.Schemas[name].Format.Should().Be(dataFormat);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", "lorem ipsum")]
+        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(uint));
+            var attribute = new OpenApiPropertyDescriptionAttribute(description);
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", OpenApiVisibilityType.Advanced)]
+        [DataRow("hello", OpenApiVisibilityType.Important)]
+        [DataRow("hello", OpenApiVisibilityType.Internal)]
+        public void Given_OpenApiSchemaVisibilityAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, OpenApiVisibilityType visibility)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(uint));
+            var attribute = new OpenApiSchemaVisibilityAttribute(visibility);
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
+            acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+        }
+
+        [DataTestMethod]
+        [DataRow("integer", null)]
+        public void Given_Type_When_ParameterVisit_Invoked_Then_It_Should_Return_Result(string dataType, string dataFormat)
+        {
+            var result = this._visitor.ParameterVisit(typeof(uint), this._strategy);
+
+            result.Type.Should().Be(dataType);
+            result.Format.Should().Be(dataFormat);
+        }
+
+        [DataTestMethod]
+        [DataRow("integer", null)]
+        public void Given_Type_When_PayloadVisit_Invoked_Then_It_Should_Return_Result(string dataType, string dataFormat)
+        {
+            var result = this._visitor.PayloadVisit(typeof(uint), this._strategy);
+
+            result.Type.Should().Be(dataType);
+            result.Format.Should().Be(dataFormat);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt32TypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt32TypeVisitorTests.cs
@@ -1,14 +1,18 @@
-using FluentAssertions;
+using System;
+using System.Collections.Generic;
+
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors;
+
+using FluentAssertions;
+
 using Microsoft.OpenApi.Any;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Newtonsoft.Json.Serialization;
-using System;
-using System.Collections.Generic;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 {

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt64TypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt64TypeVisitorTests.cs
@@ -1,0 +1,137 @@
+using FluentAssertions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors;
+using Microsoft.OpenApi.Any;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
+{
+    [TestClass]
+    public class UInt64TypeVisitorTests
+    {
+        private VisitorCollection _visitorCollection;
+        private IVisitor _visitor;
+        private NamingStrategy _strategy;
+
+        [TestInitialize]
+        public void Init()
+        {
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new UInt64TypeVisitor(this._visitorCollection);
+            this._strategy = new CamelCaseNamingStrategy();
+        }
+
+        [DataTestMethod]
+        [DataRow(typeof(ulong), false)]
+        public void Given_Type_When_IsNavigatable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
+        {
+            var result = this._visitor.IsNavigatable(type);
+
+            result.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(typeof(ulong), true)]
+        [DataRow(typeof(long), false)]
+        [DataRow(typeof(string), false)]
+        public void Given_Type_When_IsVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
+        {
+            var result = this._visitor.IsVisitable(type);
+
+            result.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(typeof(ulong), true)]
+        [DataRow(typeof(long), false)]
+        [DataRow(typeof(string), false)]
+        public void Given_Type_When_IsParameterVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
+        {
+            var result = this._visitor.IsParameterVisitable(type);
+
+            result.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(typeof(ulong), true)]
+        [DataRow(typeof(long), false)]
+        [DataRow(typeof(string), false)]
+        public void Given_Type_When_IsPayloadVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
+        {
+            var result = this._visitor.IsPayloadVisitable(type);
+
+            result.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow("integer", null)]
+        public void Given_Type_When_Visit_Invoked_Then_It_Should_Return_Result(string dataType, string dataFormat)
+        {
+            var name = "hello";
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(ulong));
+
+            this._visitor.Visit(acceptor, type, this._strategy);
+
+            acceptor.Schemas.Should().ContainKey(name);
+            acceptor.Schemas[name].Type.Should().Be(dataType);
+            acceptor.Schemas[name].Format.Should().Be(dataFormat);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", "lorem ipsum")]
+        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(ulong));
+            var attribute = new OpenApiPropertyDescriptionAttribute(description);
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", OpenApiVisibilityType.Advanced)]
+        [DataRow("hello", OpenApiVisibilityType.Important)]
+        [DataRow("hello", OpenApiVisibilityType.Internal)]
+        public void Given_OpenApiSchemaVisibilityAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, OpenApiVisibilityType visibility)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(ulong));
+            var attribute = new OpenApiSchemaVisibilityAttribute(visibility);
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
+            acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+        }
+
+        [DataTestMethod]
+        [DataRow("integer", null)]
+        public void Given_Type_When_ParameterVisit_Invoked_Then_It_Should_Return_Result(string dataType, string dataFormat)
+        {
+            var result = this._visitor.ParameterVisit(typeof(ulong), this._strategy);
+
+            result.Type.Should().Be(dataType);
+            result.Format.Should().Be(dataFormat);
+        }
+
+        [DataTestMethod]
+        [DataRow("integer", null)]
+        public void Given_Type_When_PayloadVisit_Invoked_Then_It_Should_Return_Result(string dataType, string dataFormat)
+        {
+            var result = this._visitor.PayloadVisit(typeof(ulong), this._strategy);
+
+            result.Type.Should().Be(dataType);
+            result.Format.Should().Be(dataFormat);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt64TypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt64TypeVisitorTests.cs
@@ -1,14 +1,18 @@
-using FluentAssertions;
+using System;
+using System.Collections.Generic;
+
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors;
+
+using FluentAssertions;
+
 using Microsoft.OpenApi.Any;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Newtonsoft.Json.Serialization;
-using System;
-using System.Collections.Generic;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 {


### PR DESCRIPTION
Adds support for unsigned integer types (`ushort`, `uint`, and `ulong`). Currently if an API exposes a model with an unsigned type, it is not included in the model definition in the OpenAPI spec, despite being returned by the API.

Unsigned types do not provide a `format` definition beyond stating they are integers, as the OpenAPI spec only supports `int32` and `int64` for formats, both of which explicitly specify that they are signed integers.

Example swagger UI doc generated on a function return model containing both uint and int values:
![image](https://user-images.githubusercontent.com/1991399/109587202-a6801780-7ad4-11eb-8449-f6fbb2785565.png)
