### PR TITLE
Add OpenAPI spec version to config options

### DIFF
--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/Configurations/OpenApiConfigurationOptions.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/Configurations/OpenApiConfigurationOptions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static.Configurations
@@ -32,5 +33,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static.Config
             new OpenApiServer() { Url = "https://contoso.com/api/" },
             new OpenApiServer() { Url = "https://fabrikam.com/api/" },
         };
+
+        public override OpenApiVersionType OpenApiVersion { get; set; } = OpenApiVersionType.V3;
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
@@ -19,5 +20,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
 
         /// <inheritdoc />
         public virtual List<OpenApiServer> Servers { get; set; } = new List<OpenApiServer>();
+
+        /// <inheritdoc />
+        public virtual OpenApiVersionType OpenApiVersion { get; set; } = OpenApiVersionType.V2;
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiSettings.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiSettings.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
@@ -21,5 +22,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
 
         /// <inheritdoc />
         public List<OpenApiServer> Servers { get; set; } = new List<OpenApiServer>();
+
+        /// <inheritdoc />
+        public OpenApiVersionType OpenApiVersion { get; set; } = OpenApiVersionType.V2;
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/IOpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/IOpenApiConfigurationOptions.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions
@@ -18,5 +19,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions
         /// Gets or sets the list of <see cref="OpenApiServer"/> instances.
         /// </summary>
         List<OpenApiServer> Servers { get; set; }
+
+        /// <summary>
+        /// Gets or sets the OpenAPI spec version.
+        /// </summary>
+        OpenApiVersionType OpenApiVersion { get; set; }
     }
 }

--- a/templates/OpenApiEndpoints/OpenApiHttpTrigger.cs
+++ b/templates/OpenApiEndpoints/OpenApiHttpTrigger.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
                                       .AddNamingStrategy(context.NamingStrategy)
                                       .AddVisitors(context.GetVisitorCollection())
                                       .Build(context.ApplicationAssembly)
-                                      .RenderAsync(context.GetOpenApiSpecVersion(V2), context.GetOpenApiFormat(extension))
+                                      .RenderAsync(context.GetOpenApiSpecVersion(context.OpenApiConfigurationOptions.OpenApiVersion), context.GetOpenApiFormat(extension))
                                       .ConfigureAwait(false);
 
             var content = new ContentResult()

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/DefaultOpenApiConfigurationOptionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/DefaultOpenApiConfigurationOptionsTests.cs
@@ -1,7 +1,7 @@
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
-
 using FluentAssertions;
 
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
@@ -20,6 +20,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
 
             settings.Servers.Should().NotBeNull();
             settings.Servers.Should().HaveCount(0);
+
+            settings.OpenApiVersion.Should().Be(OpenApiVersionType.V2);
         }
     }
 }


### PR DESCRIPTION
This PR is to:

* Give devs an option to choose the OpenAPI spec version either v2 or v3. Default is v2.
