### PR TITLE
Fix custom hostname for better discoverability

### DIFF
--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/Configurations/OpenApiConfigurationOptions.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/Configurations/OpenApiConfigurationOptions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
@@ -26,12 +25,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static.Config
                 Name = "MIT",
                 Url = new Uri("http://opensource.org/licenses/MIT"),
             }
-        };
-
-        public override List<OpenApiServer> Servers { get; set; } = new List<OpenApiServer>()
-        {
-            new OpenApiServer() { Url = "https://contoso.com/api/" },
-            new OpenApiServer() { Url = "https://fabrikam.com/api/" },
         };
 
         public override OpenApiVersionType OpenApiVersion { get; set; } = OpenApiVersionType.V3;

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/local.settings.json
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/local.settings.json
@@ -10,6 +10,7 @@
     "OpenApi__ApiKey": "",
     "OpenApi__AuthLevel__Document": "Anonymous",
     "OpenApi__AuthLevel__UI": "Anonymous",
-    "OpenApi__BackendProxyUrl": "http://localhost:7071"
+    "OpenApi__BackendProxyUrl": "http://localhost:7071",
+    "OpenApi__HostNames": "https://contoso.com/api/"
   }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings/AppSettingsBase.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings/AppSettingsBase.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings.Resolvers;
+﻿using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Resolvers;
 
 using Microsoft.Extensions.Configuration;
 
-namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings
 {
     /// <summary>
     /// This represents the base app settings entity.

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings/Extensions/AppSettingsExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings/Extensions/AppSettingsExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings.Extensions
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Extensions
 {
     /// <summary>
     /// This represents the entity to determine operating system.

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings/Extensions/ConfigurationBinderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings/Extensions/ConfigurationBinderExtensions.cs
@@ -2,7 +2,7 @@
 
 using Microsoft.Extensions.Configuration;
 
-namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings.Extensions
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Extensions
 {
     /// <summary>
     /// This represents the extension entity for <see cref="ConfigurationBinder"/> class.

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings/Resolvers/ConfigurationResolver.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings/Resolvers/ConfigurationResolver.cs
@@ -6,9 +6,9 @@ using System.Reflection;
 
 using Microsoft.Extensions.Configuration;
 
-using OperatingSystem = Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings.Extensions.OperationSystem;
+using OperatingSystem = Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Extensions.OperationSystem;
 
-namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings.Resolvers
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Resolvers
 {
     /// <summary>
     /// This represents the resolver entity for configuration.

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.CLI/ProjectInfo.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.CLI/ProjectInfo.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings.Extensions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Extensions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IOpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IOpenApiConfigurationOptions.cs
@@ -24,5 +24,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions
         /// Gets or sets the OpenAPI spec version.
         /// </summary>
         OpenApiVersionType OpenApiVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating whether to include the requesting hostname or not.
+        /// </summary>
+        bool IncludeRequestingHostName { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiAppSettingsBase.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiAppSettingsBase.cs
@@ -1,6 +1,6 @@
 using System.Reflection;
 
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Resolvers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiSettings.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiSettings.cs
@@ -25,5 +25,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
 
         /// <inheritdoc />
         public OpenApiVersionType OpenApiVersion { get; set; } = OpenApiVersionType.V2;
+
+        /// <inheritdoc />
+        public bool IncludeRequestingHostName { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Document.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Document.cs
@@ -81,7 +81,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
             var servers = options.Servers
                                  .Where(p => p.Url.TrimEnd('/') != baseUrl.TrimEnd('/'))
                                  .ToList();
-            servers.Insert(0, server);
+            if (!servers.Any())
+            {
+                servers.Insert(0, server);
+            }
+
+            if (options.IncludeRequestingHostName
+                && !servers.Any(p => p.Url.TrimEnd('/') == baseUrl.TrimEnd('/')))
+            {
+                servers.Insert(0, server);
+            }
 
             this.OpenApiDocument.Servers = servers;
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Resolvers/HostJsonResolver.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Resolvers/HostJsonResolver.cs
@@ -1,7 +1,7 @@
 using System;
 
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings.Extensions;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings.Resolvers;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Extensions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Resolvers;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/SwaggerUI.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/SwaggerUI.cs
@@ -69,7 +69,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
             var servers = options.Servers
                                  .Where(p => p.Url.TrimEnd('/') != baseUrl.TrimEnd('/'))
                                  .ToList();
-            servers.Insert(0, server);
+            if (!servers.Any())
+            {
+                servers.Insert(0, server);
+            }
+
+            if (options.IncludeRequestingHostName
+                && !servers.Any(p => p.Url.TrimEnd('/') == baseUrl.TrimEnd('/')))
+            {
+                servers.Insert(0, server);
+            }
 
             this._baseUrl = servers.First().Url;
             this._swaggerUiApiPrefix = prefix;

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/Configurations/OpenApiSettings.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/Configurations/OpenApiSettings.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations
         /// <summary>
         /// Gets or sets the API key to access to OpenAPI document.
         /// </summary>
-        public virtual string AuthKey { get; set; }
+        public virtual string ApiKey { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="OpenApiAuthLevelSettings"/> object.
@@ -24,5 +24,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations
         /// Gets or sets the backend URL for Azure Functions Proxy.
         /// </summary>
         public virtual string BackendProxyUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the comma delimited host names.
+        /// </summary>
+        public virtual string HostNames { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiWebJobsStartup.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiWebJobsStartup.cs
@@ -1,7 +1,7 @@
 using Microsoft.Azure.WebJobs.Extensions.OpenApi;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings.Extensions;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings.Resolvers;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Extensions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Resolvers;
 using Microsoft.Azure.WebJobs.Hosting;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Extensions.DependencyInjection;

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.Fakes/FakeProductSettings.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.Fakes/FakeProductSettings.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings.Tests.Fakes
+﻿namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Tests.Fakes
 {
     /// <summary>
     /// This represents the fake product settings entity.

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.Fakes/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.Fakes.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.Fakes/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.Fakes.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 
-    <AssemblyName>Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings.Tests.Fakes</AssemblyName>
-    <RootNamespace>Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings.Tests.Fakes</RootNamespace>
+    <AssemblyName>Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Tests.Fakes</AssemblyName>
+    <RootNamespace>Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Tests.Fakes</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests/AppSettingsBaseTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests/AppSettingsBaseTests.cs
@@ -7,7 +7,7 @@ using FluentAssertions.Common;
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings.Tests
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Tests
 {
     [TestClass]
     public class AppSettingsBaseTests

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests/Extensions/ConfigurationBinderExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests/Extensions/ConfigurationBinderExtensionsTests.cs
@@ -1,13 +1,13 @@
 using System.IO;
 
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings.Tests.Fakes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Tests.Fakes;
 
 using FluentAssertions;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings.Extensions.Tests
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Extensions.Tests
 {
     /// <summary>
     /// This represents the test entity for the <see cref="ConfigurationBinderExtensions"/> class.

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.csproj
@@ -5,8 +5,8 @@
 
     <IsPackable>false</IsPackable>
 
-    <AssemblyName>Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings.Tests</AssemblyName>
-    <RootNamespace>Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings.Tests</RootNamespace>
+    <AssemblyName>Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Tests</AssemblyName>
+    <RootNamespace>Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests/Resolvers/ConfigurationResolverTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests/Resolvers/ConfigurationResolverTests.cs
@@ -1,14 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings.Resolvers;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Resolvers;
 
 using FluentAssertions;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Configuration.AppSettings.Tests.Resolvers
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Tests.Resolvers
 {
     [TestClass]
     public class ConfigurationResolverTests

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/DefaultOpenApiConfigurationOptionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/DefaultOpenApiConfigurationOptionsTests.cs
@@ -1,7 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
 using FluentAssertions;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.OpenApi.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
@@ -22,6 +27,37 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
             settings.Servers.Should().HaveCount(0);
 
             settings.OpenApiVersion.Should().Be(OpenApiVersionType.V2);
+            settings.IncludeRequestingHostName.Should().BeFalse();
+        }
+
+        [DataTestMethod]
+        [DataRow("Development", true)]
+        [DataRow("Production", false)]
+        public void Given_Environment_When_Instantiated_Then_Property_Should_Return_Value(string environment, bool expected)
+        {
+            Environment.SetEnvironmentVariable("AZURE_FUNCTIONS_ENVIRONMENT", environment);
+
+            var settings = new DefaultOpenApiConfigurationOptions();
+
+            settings.IncludeRequestingHostName.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, 0)]
+        [DataRow("", 0)]
+        [DataRow("https://localhost", 1)]
+        [DataRow("https://localhost,https://loremipsum", 2)]
+        public void Given_EnvironmentVariable_When_GetHostNames_Invoked_Then_It_Should_Return_Result(string hostnames, int expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__HostNames", hostnames);
+
+            var settings = new DefaultOpenApiConfigurationOptions();
+            var method = typeof(DefaultOpenApiConfigurationOptions).GetMethod("GetHostNames", BindingFlags.NonPublic | BindingFlags.Static);
+
+            var result = method.Invoke(settings, null);
+
+            result.Should().BeOfType<List<OpenApiServer>>();
+            (result as List<OpenApiServer>).Should().HaveCount(expected);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/DocumentTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/DocumentTests.cs
@@ -131,13 +131,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
             ((string)json?.schemes[0]).Should().BeEquivalentTo(scheme);
         }
 
-        [TestMethod]
-        public async Task Given_ServerDetails_With_ConfigurationOptions_When_RenderAsync_Invoked_Then_It_Should_Return_Result()
+        [DataTestMethod]
+        [DataRow(true, "localhost", "localhost")]
+        [DataRow(false, "fabrikam.com", "contoso.com")]
+        public async Task Given_ServerDetails_With_ConfigurationOptions_When_RenderAsync_Invoked_Then_It_Should_Return_Result(bool includeRequestingHostName, string host, string expected)
         {
             var helper = new Mock<IDocumentHelper>();
 
             var scheme = "https";
-            var host = "localhost";
             var routePrefix = "api";
 
             var req = new Mock<HttpRequest>();
@@ -145,7 +146,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
             req.SetupGet(p => p.Host).Returns(new HostString(host));
 
             var options = new Mock<IOpenApiConfigurationOptions>();
-            options.SetupGet(p => p.Servers).Returns(new List<OpenApiServer>() { new OpenApiServer() { Url = $"https://contoso.com/{routePrefix}" } });
+            options.SetupGet(p => p.IncludeRequestingHostName).Returns(includeRequestingHostName);
+            options.SetupGet(p => p.Servers).Returns(new List<OpenApiServer>() { new OpenApiServer() { Url = $"{scheme}://contoso.com/{routePrefix}" } });
 
             var doc = new Document(helper.Object);
 
@@ -155,7 +157,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
 
             dynamic json = JObject.Parse(result);
 
-            ((string)json?.host).Should().BeEquivalentTo(host);
+            ((string)json?.host).Should().BeEquivalentTo(expected);
             ((string)json?.basePath).Should().BeEquivalentTo($"/{routePrefix}");
             ((string)json?.schemes[0]).Should().BeEquivalentTo(scheme);
         }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/Configurations/OpenApiSettingsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/Configurations/OpenApiSettingsTests.cs
@@ -1,0 +1,44 @@
+using System;
+
+using FluentAssertions;
+
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Extensions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Resolvers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests.Configurations
+{
+    [TestClass]
+    public class OpenApiSettingsTests
+    {
+        [DataTestMethod]
+        [DataRow("true", true, "lorem", "Function", AuthorizationLevel.Function, "Anonymous", AuthorizationLevel.Anonymous, "http://localhost:7071", "https://contoso.com/api/")]
+        [DataRow("false", false, "ipsum", "Anonymous", AuthorizationLevel.Anonymous, "Function", AuthorizationLevel.Function, "http://contoso", "https://fabrikam.com/api/")]
+        public void Given_EnvironmentVariables_When_Instantiated_Then_It_Should_Return_Result(string hideSwaggerUI, bool expectedHideSwaggerUI, string apiKey,
+                                                                                              string authLevelDoc, AuthorizationLevel expectedAuthLevelDoc,
+                                                                                              string authLevelUI, AuthorizationLevel expectedAuthLevelUI,
+                                                                                              string proxyUrl, string hostnames)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__HideSwaggerUI", hideSwaggerUI);
+            Environment.SetEnvironmentVariable("OpenApi__ApiKey", apiKey);
+            Environment.SetEnvironmentVariable("OpenApi__AuthLevel__Document", authLevelDoc);
+            Environment.SetEnvironmentVariable("OpenApi__AuthLevel__UI", authLevelUI);
+            Environment.SetEnvironmentVariable("OpenApi__BackendProxyUrl", proxyUrl);
+            Environment.SetEnvironmentVariable("OpenApi__HostNames", hostnames);
+
+            var config = ConfigurationResolver.Resolve();
+            var settings = config.Get<OpenApiSettings>("OpenApi");
+
+            settings.HideSwaggerUI.Should().Be(expectedHideSwaggerUI);
+            settings.ApiKey.Should().Be(apiKey);
+            settings.AuthLevel.Document.Should().Be(expectedAuthLevelDoc);
+            settings.AuthLevel.UI.Should().Be(expectedAuthLevelUI);
+            settings.BackendProxyUrl.Should().Be(proxyUrl);
+            settings.HostNames.Should().Be(hostnames);
+        }
+    }
+}


### PR DESCRIPTION
This PR is:

* To give devs a choice to configure the first hostname so that APIM can pass their request URL
