### PR TITLE
Fix OpenApiConfigurationResolver

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  // "azureFunctions.deploySubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V1Proxy/bin/Release/netcoreapp3.1/publish",
+  // "azureFunctions.deploySubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC/bin/Release/netcoreapp2.1/publish",
+  // "azureFunctions.deploySubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static/bin/Release/netcoreapp2.1/publish",
   // "azureFunctions.deploySubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/bin/Release/netcoreapp3.1/publish",
   "azureFunctions.deploySubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/bin/Release/netcoreapp3.1/publish",
   "azureFunctions.projectLanguage": "C#",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -50,6 +50,7 @@
         // "${workspaceFolder}/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.csproj",
         // "${workspaceFolder}/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.CLI/Microsoft.Azure.WebJobs.Extensions.OpenApi.CLI.csproj",
         // "${workspaceFolder}/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.csproj",
+        // "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V1Proxy/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V1Proxy.csproj",
         // "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC.csproj",
         // "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static.csproj",
         // "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC.csproj",
@@ -80,6 +81,7 @@
 			"type": "func",
 			"dependsOn": "build",
 			"options": {
+				// "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V1Proxy/bin/Debug/netcoreapp3.1"
 				// "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC/bin/Debug/netcoreapp2.1"
 				// "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static/bin/Debug/netcoreapp2.1"
 				// "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/bin/Debug/netcoreapp3.1"

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/Configurations/AppSettings.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/Configurations/AppSettings.cs
@@ -1,0 +1,22 @@
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Extensions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC.Configurations
+{
+    public class AppSettings : OpenApiAppSettingsBase
+    {
+        public AppSettings()
+            : base()
+        {
+            this.OpenApi = this.Config.Get<OpenApiSettings>("OpenApi");
+        }
+
+        public virtual OpenApiSettings OpenApi { get; set; }
+    }
+
+    public class OpenApiSettings
+    {
+        public virtual string ApiKey { get; set; }
+    }
+}

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/DefaultHttpTrigger.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/DefaultHttpTrigger.cs
@@ -8,6 +8,8 @@ using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC.Configurations;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json;
@@ -16,6 +18,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC
 {
     public class DefaultHttpTrigger
     {
+        private readonly AppSettings _settings;
+
+        public DefaultHttpTrigger(AppSettings settings)
+        {
+            this._settings = settings.ThrowIfNullOrDefault();
+        }
+
         [FunctionName("DefaultHttpTrigger")]
         [OpenApiOperation(operationId: "Run", tags: new[] { "name" })]
         [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, Name = "code", In = OpenApiSecurityLocationType.Query)]
@@ -26,6 +35,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC
             ILogger log)
         {
             log.LogInformation("C# HTTP trigger function processed a request.");
+            log.LogInformation($"ApiKey: {this._settings.OpenApi.ApiKey}");
 
             string name = req.Query["name"];
 

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/StartUp.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/StartUp.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.Services;
-using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+﻿using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.Services;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC.Configurations;
 using Microsoft.Extensions.DependencyInjection;
 
 [assembly: FunctionsStartup(typeof(Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC.StartUp))]
@@ -13,6 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC
         /// <inheritdoc />
         public override void Configure(IFunctionsHostBuilder builder)
         {
+            builder.Services.AddSingleton<AppSettings>();
             builder.Services.AddTransient<IDummyHttpService, DummyHttpService>();
         }
     }

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/local.settings.json
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/local.settings.json
@@ -4,6 +4,6 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
 
-    "OpenApi__ApiKey": ""
-  },
+    "OpenApi__ApiKey": "helloworld"
+  }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Resolvers/OpenApiConfigurationResolver.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Resolvers/OpenApiConfigurationResolver.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Resolvers
         public static IOpenApiConfigurationOptions Resolve(Assembly assembly)
         {
             var type = assembly.GetTypes()
-                               .SingleOrDefault(p => p.GetInterface("IOpenApiConfigurationOptions", ignoreCase: true).IsNullOrDefault() == false);
+                               .SingleOrDefault(p => p.GetInterface("IOpenApiConfigurationOptions", ignoreCase: true).IsNullOrDefault() == false
+                                                  && p.GetCustomAttribute<ObsoleteAttribute>(inherit: false).IsNullOrDefault() == true);
             if (type.IsNullOrDefault())
             {
                 var settings = new DefaultOpenApiConfigurationOptions();

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Resolvers/OpenApiConfigurationResolverTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Resolvers/OpenApiConfigurationResolverTests.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using FluentAssertions;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Resolvers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -17,6 +18,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Resolvers
             typeof(OpenApiConfigurationResolver)
                 .Should().HaveMethod("Resolve", new[] { typeof(Assembly) })
                 .Which.Should().Return<IOpenApiConfigurationOptions>();
+        }
+
+        [TestMethod]
+        public void Given_ExecutingAssembly_When_Resolve_Invoked_Then_It_Should_Return_Result()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+
+            var result = OpenApiConfigurationResolver.Resolve(assembly);
+
+            result.Should().BeOfType<DefaultOpenApiConfigurationOptions>();
+        }
+
+        [TestMethod]
+        public void Given_Assembly_When_Resolve_Invoked_Then_It_Should_Return_Result()
+        {
+            var assembly = Assembly.GetAssembly(typeof(DefaultOpenApiConfigurationOptions));
+
+            var result = OpenApiConfigurationResolver.Resolve(assembly);
+
+            result.Should().BeOfType<DefaultOpenApiConfigurationOptions>();
         }
     }
 }


### PR DESCRIPTION
This PR is:

* To fix getting more than one `IOpenApiConfigurationOptions` instance from `Microsoft.Azure.WebJobs.Extensions.OpenApi.Core` library.
