### PR TITLE
Examples for OpenAPI V2/V3

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IDocument.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IDocument.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors;
 using Microsoft.OpenApi;
 using Microsoft.OpenApi.Models;
@@ -60,15 +61,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions
         /// Builds OpenAPI document.
         /// </summary>
         /// <param name="assemblyPath">Assembly file path.</param>
+        /// <param name="version">OpenAPI spec version.</param>
         /// <returns><see cref="IDocument"/> instance.</returns>
-        IDocument Build(string assemblyPath);
+        IDocument Build(string assemblyPath, OpenApiVersionType version = OpenApiVersionType.V2);
 
         /// <summary>
         /// Builds OpenAPI document.
         /// </summary>
         /// <param name="assembly"><see cref="Assembly"/> instance.</param>
+        /// <param name="version">OpenAPI spec version.</param>
         /// <returns><see cref="IDocument"/> instance.</returns>
-        IDocument Build(Assembly assembly);
+        IDocument Build(Assembly assembly, OpenApiVersionType version = OpenApiVersionType.V2);
 
         /// <summary>
         /// Renders OpenAPI document.

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IDocumentHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IDocumentHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors;
 using Microsoft.OpenApi.Models;
 
@@ -91,8 +92,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions
         /// <param name="element"><see cref="MethodInfo"/> instance.</param>
         /// <param name="namingStrategy"><see cref="NamingStrategy"/> instance to create the JSON schema from .NET Types.</param>
         /// <param name="collection"><see cref="VisitorCollection"/> instance to process parameters.</param>
+        /// <param name="version">OpenAPI spec version.</param>
         /// <returns><see cref="OpenApiRequestBody"/> instance.</returns>
-        OpenApiRequestBody GetOpenApiRequestBody(MethodInfo element, NamingStrategy namingStrategy, VisitorCollection collection);
+        OpenApiRequestBody GetOpenApiRequestBody(MethodInfo element, NamingStrategy namingStrategy, VisitorCollection collection, OpenApiVersionType version = OpenApiVersionType.V2);
 
         /// <summary>
         /// Gets the <see cref="OpenApiResponses"/> instance.
@@ -109,8 +111,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions
         /// <param name="element"><see cref="MethodInfo"/> instance.</param>
         /// <param name="namingStrategy"><see cref="NamingStrategy"/> instance to create the JSON schema from .NET Types.</param>
         /// <param name="collection"><see cref="VisitorCollection"/> instance to process parameters.</param>
+        /// <param name="version">OpenAPI spec version.</param>
         /// <returns><see cref="OpenApiResponses"/> instance.</returns>
-        OpenApiResponses GetOpenApiResponses(MethodInfo element, NamingStrategy namingStrategy, VisitorCollection collection);
+        OpenApiResponses GetOpenApiResponses(MethodInfo element, NamingStrategy namingStrategy, VisitorCollection collection, OpenApiVersionType version = OpenApiVersionType.V2);
 
         /// <summary>
         /// Gets the collection of <see cref="OpenApiSchema"/> instances.
@@ -118,7 +121,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions
         /// <param name="elements">List of <see cref="MethodInfo"/> instance.</param>
         /// <param name="namingStrategy"><see cref="NamingStrategy"/> instance to create the JSON schema from .NET Types.</param>
         /// <param name="collection"><see cref="VisitorCollection"/> instance to add types to schema.</param>
-        /// <returns>Collection of <see cref="OpenApiSchema"/> instance.</returns>
+        /// /// <returns>Collection of <see cref="OpenApiSchema"/> instance.</returns>
         Dictionary<string, OpenApiSchema> GetOpenApiSchemas(List<MethodInfo> elements, NamingStrategy namingStrategy, VisitorCollection collection);
 
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Document.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Document.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors;
 using Microsoft.OpenApi;
@@ -114,15 +115,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
         }
 
         /// <inheritdoc />
-        public IDocument Build(string assemblyPath)
+        public IDocument Build(string assemblyPath, OpenApiVersionType version = OpenApiVersionType.V2)
         {
             var assembly = Assembly.LoadFrom(assemblyPath);
 
-            return this.Build(assembly);
+            return this.Build(assembly, version);
         }
 
         /// <inheritdoc />
-        public IDocument Build(Assembly assembly)
+        public IDocument Build(Assembly assembly, OpenApiVersionType version = OpenApiVersionType.V2)
         {
             if (this._strategy.IsNullOrDefault())
             {
@@ -165,8 +166,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
 
                 operation.Security = this._helper.GetOpenApiSecurityRequirement(method, this._strategy);
                 operation.Parameters = this._helper.GetOpenApiParameters(method, trigger, this._strategy, this._collection);
-                operation.RequestBody = this._helper.GetOpenApiRequestBody(method, this._strategy, this._collection);
-                operation.Responses = this._helper.GetOpenApiResponses(method, this._strategy, this._collection);
+                operation.RequestBody = this._helper.GetOpenApiRequestBody(method, this._strategy, this._collection, version);
+                operation.Responses = this._helper.GetOpenApiResponses(method, this._strategy, this._collection, version);
 
                 operations[verb] = operation;
                 item.Operations = operations;

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
         }
 
         /// <inheritdoc />
-        public OpenApiRequestBody GetOpenApiRequestBody(MethodInfo element, NamingStrategy namingStrategy, VisitorCollection collection)
+        public OpenApiRequestBody GetOpenApiRequestBody(MethodInfo element, NamingStrategy namingStrategy, VisitorCollection collection, OpenApiVersionType version = OpenApiVersionType.V2)
         {
             var attributes = element.GetCustomAttributes<OpenApiRequestBodyAttribute>(inherit: false);
             if (!attributes.Any())
@@ -184,7 +184,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
             }
 
             var contents = attributes.Where(p => p.Deprecated == false)
-                                     .ToDictionary(p => p.ContentType, p => p.ToOpenApiMediaType(namingStrategy, collection));
+                                     .ToDictionary(p => p.ContentType, p => p.ToOpenApiMediaType(namingStrategy, collection, version));
 
             if (contents.Any())
             {
@@ -212,11 +212,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
         }
 
         /// <inheritdoc />
-        public OpenApiResponses GetOpenApiResponses(MethodInfo element, NamingStrategy namingStrategy, VisitorCollection collection)
+        public OpenApiResponses GetOpenApiResponses(MethodInfo element, NamingStrategy namingStrategy, VisitorCollection collection, OpenApiVersionType version = OpenApiVersionType.V2)
         {
             var responsesWithBody = element.GetCustomAttributes<OpenApiResponseWithBodyAttribute>(inherit: false)
                                            .Where(p => p.Deprecated == false)
-                                           .Select(p => new { StatusCode = p.StatusCode, Response = p.ToOpenApiResponse(namingStrategy) });
+                                           .Select(p => new { StatusCode = p.StatusCode, Response = p.ToOpenApiResponse(namingStrategy, version: version) });
 
             var responsesWithoutBody = element.GetCustomAttributes<OpenApiResponseWithoutBodyAttribute>(inherit: false)
                                               .Select(p => new { StatusCode = p.StatusCode, Response = p.ToOpenApiResponse(namingStrategy) });

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiPayloadAttributeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiPayloadAttributeExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors;
 using Microsoft.OpenApi.Models;
 
@@ -22,8 +23,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
         /// <param name="attribute">OpenApi payload attribute.</param>
         /// <param name="namingStrategy"><see cref="NamingStrategy"/> instance to create the JSON schema from .NET Types.</param>
         /// <param name="collection"><see cref="VisitorCollection"/> instance.</param>
+        /// <param name="version">OpenAPI spec version.</param>
         /// <returns><see cref="OpenApiMediaType"/> instance.</returns>
-        public static OpenApiMediaType ToOpenApiMediaType<T>(this T attribute, NamingStrategy namingStrategy = null, VisitorCollection collection = null) where T : OpenApiPayloadAttribute
+        public static OpenApiMediaType ToOpenApiMediaType<T>(this T attribute, NamingStrategy namingStrategy = null, VisitorCollection collection = null, OpenApiVersionType version = OpenApiVersionType.V2) where T : OpenApiPayloadAttribute
         {
             attribute.ThrowIfNullOrDefault();
 
@@ -80,7 +82,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
             var examples = (IDictionary<string, OpenApiExample>)example.Build(namingStrategy).Examples;
 
             mediaType.Examples = examples;
-            mediaType.Example = examples.First().Value.Value;
+            if (version == OpenApiVersionType.V2)
+            {
+                mediaType.Example = examples.First().Value.Value;
+            }
 
             return mediaType;
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiResponseWithBodyAttributeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiResponseWithBodyAttributeExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
@@ -22,15 +23,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
         /// <param name="attribute"><see cref="OpenApiResponseWithBodyAttribute"/> instance.</param>
         /// <param name="namingStrategy"><see cref="NamingStrategy"/> instance to create the JSON schema from .NET Types.</param>
         /// <param name="collection"><see cref="VisitorCollection"/> instance.</param>
+        /// <param name="version">OpenAPI spec version.</param>
         /// <returns><see cref="OpenApiResponse"/> instance.</returns>
-        public static OpenApiResponse ToOpenApiResponse(this OpenApiResponseWithBodyAttribute attribute, NamingStrategy namingStrategy = null, VisitorCollection collection = null)
+        public static OpenApiResponse ToOpenApiResponse(this OpenApiResponseWithBodyAttribute attribute, NamingStrategy namingStrategy = null, VisitorCollection collection = null, OpenApiVersionType version = OpenApiVersionType.V2)
         {
             attribute.ThrowIfNullOrDefault();
 
             var description = string.IsNullOrWhiteSpace(attribute.Description)
                                   ? $"Payload of {attribute.BodyType.GetOpenApiDescription()}"
                                   : attribute.Description;
-            var mediaType = attribute.ToOpenApiMediaType<OpenApiResponseWithBodyAttribute>(namingStrategy, collection);
+            var mediaType = attribute.ToOpenApiMediaType<OpenApiResponseWithBodyAttribute>(namingStrategy, collection, version);
             var content = new Dictionary<string, OpenApiMediaType>()
                               {
                                   { attribute.ContentType, mediaType }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/IOpenApiHttpTriggerContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/IOpenApiHttpTriggerContext.cs
@@ -84,6 +84,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
         VisitorCollection GetVisitorCollection();
 
         /// <summary>
+        /// Gets the <see cref="OpenApiVersionType"/> value.
+        /// </summary>
+        /// <param name="version">OpenAPI spec version. It can be either <c>v2</c> or <c>v3</c>.</param>
+        /// <returns>Returns the <see cref="OpenApiVersionType"/> value.</returns>
+        OpenApiVersionType GetOpenApiVersionType(string version = "v2");
+
+        /// <summary>
         /// Gets the <see cref="OpenApiSpecVersion"/> value.
         /// </summary>
         /// <param name="version">OpenAPI spec version. It can be either <c>v2</c> or <c>v3</c>.</param>

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiHttpTriggerContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiHttpTriggerContext.cs
@@ -149,6 +149,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
         }
 
         /// <inheritdoc />
+        public virtual OpenApiVersionType GetOpenApiVersionType(string version = "v2")
+        {
+            var parsed = Enum.TryParse(version, true, out OpenApiVersionType output)
+                             ? output
+                             : throw new InvalidOperationException("Invalid OpenAPI version");
+
+            return parsed;
+        }
+
+        /// <inheritdoc />
         public virtual OpenApiSpecVersion GetOpenApiSpecVersion(string version = "v2")
         {
             var parsed = Enum.TryParse(version, true, out OpenApiVersionType output)

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiTriggerFunctions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiTriggerFunctions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
                                       .AddServer(req, context.HttpSettings.RoutePrefix, context.OpenApiConfigurationOptions)
                                       .AddNamingStrategy(context.NamingStrategy)
                                       .AddVisitors(context.GetVisitorCollection())
-                                      .Build(context.ApplicationAssembly)
+                                      .Build(context.ApplicationAssembly, context.OpenApiConfigurationOptions.OpenApiVersion)
                                       .RenderAsync(context.GetOpenApiSpecVersion(context.OpenApiConfigurationOptions.OpenApiVersion), context.GetOpenApiFormat(extension))
                                       .ConfigureAwait(false);
 
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
                                       .AddServer(req, context.HttpSettings.RoutePrefix, context.OpenApiConfigurationOptions)
                                       .AddNamingStrategy(context.NamingStrategy)
                                       .AddVisitors(context.GetVisitorCollection())
-                                      .Build(context.ApplicationAssembly)
+                                      .Build(context.ApplicationAssembly, context.GetOpenApiVersionType(version))
                                       .RenderAsync(context.GetOpenApiSpecVersion(version), context.GetOpenApiFormat(extension))
                                       .ConfigureAwait(false);
 


### PR DESCRIPTION
This PR is to

* Fix the `example` attribute to display only for V2.
