### PR TITLE
Stack overflow bug fixed when one of the properties  type is Type  in response model

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
@@ -46,6 +46,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
             {
                 isVisitable = false;
             }
+            else if (type == typeof(Type))
+            {
+                isVisitable = false;
+            }
             else if (type.IsOpenApiArray())
             {
                 isVisitable = false;
@@ -70,6 +74,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
             {
                 isVisitable = false;
             }
+            
 
             return isVisitable;
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/RecursiveObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/RecursiveObjectTypeVisitor.cs
@@ -40,6 +40,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
             {
                 isVisitable = false;
             }
+            if (type == typeof(Type))
+            {
+                isVisitable = false;
+            }
             if (type.IsOpenApiNullable())
             {
                 isVisitable = false;
@@ -52,6 +56,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
             {
                 isVisitable = false;
             }
+            
 
             return isVisitable;
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/TypeTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/TypeTypeVisitor.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Newtonsoft.Json.Serialization;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
+{
+    /// <summary>
+    /// This represents the type visitor for <see cref="Type"/>.
+    /// </summary>
+    public class TypeTypeVisitor : TypeVisitor
+    {
+        /// <inheritdoc />
+        public TypeTypeVisitor(VisitorCollection visitorCollection) : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
+        public override bool IsVisitable(Type type)
+        {
+            return type == typeof(Type);
+        }
+
+        /// <inheritdoc />
+        public override bool IsParameterVisitable(Type type)
+        {
+            return false;
+        }
+
+        /// <inheritdoc />
+        public override bool IsNavigatable(Type type)
+        {
+            return false;
+        }
+
+        /// <inheritdoc />
+        public override bool IsPayloadVisitable(Type type)
+        {
+            return false;
+        }
+
+        /// <inheritdoc />
+        public override void Visit(IAcceptor acceptor, KeyValuePair<string, Type> type, NamingStrategy namingStrategy, params Attribute[] attributes)
+        {
+            this.Visit(acceptor, name: type.Key, title: null, dataType: "string", dataFormat: null, attributes: attributes);
+        }
+    }
+}


### PR DESCRIPTION
When response model in has a Type property this package throw an stack overflow exception  because of visitors always trigger OpenApiSchemaAcceptor

For example model class

```c#
/// <summary>
    /// This represents the model entity for pet of Swagger Pet Store.
    /// </summary>
    public class Pet
    {
        /// <summary>
        /// Gets or sets the pet ID.
        /// </summary>
        public long? Id { get; set; }

        /// <summary>
        /// Gets or sets the category.
        /// </summary>
        public Category Category { get; set; }

        /// <summary>
        /// Gets or sets the name.
        /// </summary>
        [JsonRequired]
        public string Name { get; set; }

        /// <summary>
        /// Gets or sets the list of photo URLs.
        /// </summary>
        [JsonRequired]
        public List<string> PhotoUrls { get; set; } = new List<string>();

        /// <summary>
        /// Gets or sets the list of tags.
        /// </summary>
        public List<Tag> Tags { get; set; }

        [JsonIgnore]
        /// <summary>
        /// Gets or sets the <see cref="PetStatus"/> value.
        /// </summary>
        /// 
        public PetStatus? Status { get; set; }

        // Stack Overflow exception 
        public Type StackOverflow { get; set; }

    }


```


