### PR TITLE
Enum string-values should not be changed

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
@@ -160,12 +160,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
         /// <param name="type"><see cref="Type"/> instance.</param>
         /// <param name="namingStrategy"><see cref="NamingStrategy"/> instance.</param>
         /// <returns>Returns the list of underlying enum name.</returns>
-        public static List<IOpenApiAny> ToOpenApiStringCollection(this Type type, NamingStrategy namingStrategy)
+        public static List<IOpenApiAny> ToOpenApiStringCollection(this Type type, NamingStrategy namingStrategy = null)
         {
             if (!type.IsUnflaggedEnumType())
             {
                 return null;
             }
+
+            // namingStrategy null check
+            if (namingStrategy.IsNullOrDefault())
+            {
+                namingStrategy = new DefaultNamingStrategy();
+            }
+            // namingStrategy null check
 
             var members = type.GetMembers(BindingFlags.Public | BindingFlags.Static);
             var names = members.Select(p => p.ToDisplayName(namingStrategy));

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/StringEnumTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/StringEnumTypeVisitor.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
             }
 
             // Adds enum values to the schema.
-            var enums = type.Value.ToOpenApiStringCollection(namingStrategy);
+            var enums = type.Value.ToOpenApiStringCollection(null);
 
             var schema = new OpenApiSchema()
             {

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/StringEnumTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/StringEnumTypeVisitor.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
             }
 
             // Adds enum values to the schema.
-            var enums = type.Value.ToOpenApiStringCollection(null);
+            var enums = type.Value.ToOpenApiStringCollection();
 
             var schema = new OpenApiSchema()
             {

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes/FakeStringEnum.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes/FakeStringEnum.cs
@@ -22,5 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes
         [EnumMember(Value = "dolor")]
         [Display("sit")]
         StringValue3,
+
+        StringValue4,
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/EnumExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/EnumExtensionsTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
         [DataRow(FakeStringEnum.StringValue1, "lorem")]
         [DataRow(FakeStringEnum.StringValue2, "ipsum")]
         [DataRow(FakeStringEnum.StringValue3, "dolor")]
+        [DataRow(FakeStringEnum.StringValue4, "StringValue4")]
         public void Given_Enum_Method_Should_Return_Value(FakeStringEnum @enum, string expected)
         {
             var name = EnumExtensions.ToDisplayName(@enum);

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/MemberInfoExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/MemberInfoExtensionsTests.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
         [DataRow("StringValue1", "lorem")]
         [DataRow("StringValue2", "ipsum")]
         [DataRow("StringValue3", "dolor")]
+        [DataRow("StringValue4", "StringValue4")]
         public void Given_MemberInfo_When_ToDisplayName_Invoked_Then_It_Should_Return_Result(string memberName, string expected)
         {
             var member = typeof(FakeStringEnum).GetMember(memberName).First();

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/StringEnumTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/StringEnumTypeVisitorTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
             var name = "hello";
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(FakeStringEnum));
-            var enums = enumType.ToOpenApiStringCollection(null);
+            var enums = enumType.ToOpenApiStringCollection();
 
             this._visitor.Visit(acceptor, type, this._strategy);
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/StringEnumTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/StringEnumTypeVisitorTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
             var name = "hello";
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(FakeStringEnum));
-            var enums = enumType.ToOpenApiStringCollection(this._strategy);
+            var enums = enumType.ToOpenApiStringCollection(null);
 
             this._visitor.Visit(acceptor, type, this._strategy);
 


### PR DESCRIPTION
Enum properties should be displayed as their actual value, they should not be changed to follow a naming strategy.

Considering this enum
```
[JsonConverter(typeof(StringEnumConverter))]
public enum DrinkSize
{
    Small = 0,
    Medium = 1,
    Large = 2
}
```

Currently is displayed as:
![before](https://user-images.githubusercontent.com/3026716/124260233-bdd91b00-db2f-11eb-9c62-e7a7ca4f58b0.png)

This PR changes the behavior so the enum is displayed as-is:
![after](https://user-images.githubusercontent.com/3026716/124260281-cd586400-db2f-11eb-9545-603563f2fce2.png)


Resolves #103