### PR TITLE
Update Nullable feature

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,17 +1,17 @@
 {
-  "azureFunctions.deploySubpath": "samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5/bin/Release/net5.0/publish",
+  // "azureFunctions.deploySubpath": "samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5/bin/Release/net5.0/publish",
   // "azureFunctions.deploySubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V1Proxy/bin/Release/netcoreapp3.1/publish",
   // "azureFunctions.deploySubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC/bin/Release/netcoreapp2.1/publish",
   // "azureFunctions.deploySubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static/bin/Release/netcoreapp2.1/publish",
   // "azureFunctions.deploySubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/bin/Release/netcoreapp3.1/publish",
-  // "azureFunctions.deploySubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/bin/Release/netcoreapp3.1/publish",
+  "azureFunctions.deploySubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/bin/Release/netcoreapp3.1/publish",
 
-  "azureFunctions.projectSubpath": "samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5",
+  // "azureFunctions.projectSubpath": "samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5",
   // "azureFunctions.projectSubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V1Proxy",
   // "azureFunctions.projectSubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC",
   // "azureFunctions.projectSubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static",
   // "azureFunctions.projectSubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC",
-  // "azureFunctions.projectSubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static",
+  "azureFunctions.projectSubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static",
 
   "azureFunctions.projectLanguage": "C#",
   "azureFunctions.projectRuntime": "~3",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,12 +12,12 @@
       "type": "process",
       "problemMatcher": "$msCompile",
       "options": {
-        "cwd": "${workspaceFolder}/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5"
+        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V1Proxy"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static"
+        "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static"
       }
     },
     {
@@ -36,12 +36,12 @@
       },
       "problemMatcher": "$msCompile",
       "options": {
-        "cwd": "${workspaceFolder}/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5"
+        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V1Proxy"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static"
+        "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static"
       }
     },
     {
@@ -57,12 +57,12 @@
       "type": "process",
       "problemMatcher": "$msCompile",
       "options": {
-        "cwd": "${workspaceFolder}/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5"
+        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V1Proxy"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static"
+        "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static"
       }
     },
     {
@@ -79,12 +79,12 @@
       "dependsOn": "clean release",
       "problemMatcher": "$msCompile",
       "options": {
-        "cwd": "${workspaceFolder}/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5"
+        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V1Proxy"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static"
+        "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static"
       }
     },
     {
@@ -104,12 +104,12 @@
       "type": "func",
       "dependsOn": "build",
       "options": {
-        "cwd": "${workspaceFolder}/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5/bin/Debug/net5.0"
+        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5/bin/Debug/net5.0"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Proxy/bin/Debug/netcoreapp3.1"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC/bin/Debug/netcoreapp2.1"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static/bin/Debug/netcoreapp2.1"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/bin/Debug/netcoreapp3.1"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/bin/Debug/netcoreapp3.1"
+        "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/bin/Debug/netcoreapp3.1"
       },
       "command": "host start",
       "isBackground": true,

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.Models/DummyModel.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.Models/DummyModel.cs
@@ -4,10 +4,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.Models
 {
     public class DummyModel
     {
-        [OpenApiProperty(Description = "The number of Dummy")]
+        [OpenApiProperty(Nullable = false, Description = "The number of Dummy")]
         public int Number { get; set; }
 
-        [OpenApiProperty(Description = "The text of Dummy")]
+        [OpenApiProperty(Nullable = true, Description = "The text of Dummy")]
         public string Text { get; set; }
     }
 }

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.Models/DummyRequestModel.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.Models/DummyRequestModel.cs
@@ -1,5 +1,7 @@
 using System;
 
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.Models
 {
     public class DummyRequestModel
@@ -19,6 +21,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.Models
         public decimal DecimalValue { get; set; }
 
         public int? NullableIntValue { get; set; }
+
+        [OpenApiProperty(Nullable = false)]
+        public int? NotNullableIntValue { get; set; }
 
         public bool BoolValue { get; set; }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/EnumExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/EnumExtensions.cs
@@ -19,6 +19,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
         /// <param name="enum">Enum value.</param>
         /// <param name="namingStrategy"><see cref="NamingStrategy"/> instance.</param>
         /// <returns>Display name of the enum value.</returns>
+        public static string ToString(this Enum @enum, NamingStrategy namingStrategy = null)
+        {
+            return @enum.ToDisplayName(namingStrategy);
+        }
+
+        /// <summary>
+        /// Gets the display name of the enum value.
+        /// </summary>
+        /// <param name="enum">Enum value.</param>
+        /// <param name="namingStrategy"><see cref="NamingStrategy"/> instance.</param>
+        /// <returns>Display name of the enum value.</returns>
         public static string ToDisplayName(this Enum @enum, NamingStrategy namingStrategy = null)
         {
             if (namingStrategy.IsNullOrDefault())

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
@@ -137,9 +137,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
         /// </summary>
         /// <param name="type"><see cref="Type"/> instance.</param>
         /// <returns>Returns <c>True</c>, if the type is identified as enum without flags; otherwise returns <c>False</c>.</returns>
-        public static bool IsUnflaggedEnumType(this Type type)
+        public static bool IsEnumType(this Type type)
         {
             var isEnum = typeof(Enum).IsAssignableFrom(type);
+
+            return isEnum;
+        }
+
+        /// <summary>
+        /// Checks whether the given type is enum without flags or not.
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> instance.</param>
+        /// <returns>Returns <c>True</c>, if the type is identified as enum without flags; otherwise returns <c>False</c>.</returns>
+        public static bool IsUnflaggedEnumType(this Type type)
+        {
+            var isEnum = type.IsEnumType();
             if (!isEnum)
             {
                 return false;

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/Int16EnumTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/Int16EnumTypeVisitor.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
                 if (!attr.IsNullOrDefault())
                 {
                     schema.Nullable = this.GetOpenApiPropertyNullable(attr as OpenApiPropertyAttribute);
-                    schema.Default = this.GetOpenApiPropertyDefault(attr as OpenApiPropertyAttribute);
+                    schema.Default = this.GetOpenApiPropertyDefault<short>(attr as OpenApiPropertyAttribute);
                     schema.Description = this.GetOpenApiPropertyDescription(attr as OpenApiPropertyAttribute);
                 }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/Int32EnumTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/Int32EnumTypeVisitor.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
                 if (!attr.IsNullOrDefault())
                 {
                     schema.Nullable = this.GetOpenApiPropertyNullable(attr as OpenApiPropertyAttribute);
-                    schema.Default = this.GetOpenApiPropertyDefault(attr as OpenApiPropertyAttribute);
+                    schema.Default = this.GetOpenApiPropertyDefault<int>(attr as OpenApiPropertyAttribute);
                     schema.Description = this.GetOpenApiPropertyDescription(attr as OpenApiPropertyAttribute);
                 }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/Int64EnumTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/Int64EnumTypeVisitor.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
                 if (!attr.IsNullOrDefault())
                 {
                     schema.Nullable = this.GetOpenApiPropertyNullable(attr as OpenApiPropertyAttribute);
-                    schema.Default = this.GetOpenApiPropertyDefault(attr as OpenApiPropertyAttribute);
+                    schema.Default = this.GetOpenApiPropertyDefault<long>(attr as OpenApiPropertyAttribute);
                     schema.Description = this.GetOpenApiPropertyDescription(attr as OpenApiPropertyAttribute);
                 }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/NullableObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/NullableObjectTypeVisitor.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
                 Attribute attr = attributes.OfType<OpenApiPropertyAttribute>().SingleOrDefault();
                 if (!attr.IsNullOrDefault())
                 {
-                    schema.Nullable = true;
+                    schema.Nullable = this.GetOpenApiPropertyNullable(attr as OpenApiPropertyAttribute);
                     schema.Default = this.GetOpenApiPropertyDefault(attr as OpenApiPropertyAttribute);
                     schema.Description = this.GetOpenApiPropertyDescription(attr as OpenApiPropertyAttribute);
                 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/StringEnumTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/StringEnumTypeVisitor.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
                 if (!attr.IsNullOrDefault())
                 {
                     schema.Nullable = this.GetOpenApiPropertyNullable(attr as OpenApiPropertyAttribute);
-                    schema.Default = this.GetOpenApiPropertyDefault(attr as OpenApiPropertyAttribute);
+                    schema.Default = this.GetOpenApiPropertyDefault<string>(attr as OpenApiPropertyAttribute);
                     schema.Description = this.GetOpenApiPropertyDescription(attr as OpenApiPropertyAttribute);
                 }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/StringTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/StringTypeVisitor.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
-
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.OpenApi.Models;
 
 using Newtonsoft.Json.Serialization;
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
         /// <inheritdoc />
         public override bool IsVisitable(Type type)
         {
-            var isVisitable = this.IsVisitable(type, TypeCode.String);
+            var isVisitable = this.IsVisitable(type, TypeCode.String) && !type.IsOpenApiNullable();
 
             return isVisitable;
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/TypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/TypeVisitor.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
 
             if (@default is decimal)
             {
-                return new OpenApiDouble((double) @default);
+                return new OpenApiDouble(Convert.ToDouble(@default));
             }
 
             if (@default is short)
@@ -272,17 +272,76 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
 
             if (@default is ushort)
             {
-                return new OpenApiInteger((ushort) @default);
+                return new OpenApiInteger(Convert.ToInt16(@default));
             }
 
             if (@default is uint)
             {
-                return new OpenApiInteger((int) @default);
+                return new OpenApiInteger(Convert.ToInt32(@default));
             }
 
             if (@default is ulong)
             {
+                return new OpenApiLong(Convert.ToInt64(@default));
+            }
+
+            if (@default is Guid)
+            {
+                return new OpenApiString(Convert.ToString(@default));
+            }
+
+            return new OpenApiString((string) @default);
+        }
+
+        /// <summary>
+        /// Gets the default value from the <see cref="OpenApiPropertyAttribute"/> instance.
+        /// </summary>
+        /// <typeparam name="T">Type to compare.</typeparam>
+        /// <param name="attr"><see cref="OpenApiPropertyAttribute"/> instance.</param>
+        /// <returns>Returns the default data.</returns>
+        protected IOpenApiAny GetOpenApiPropertyDefault<T>(OpenApiPropertyAttribute attr)
+        {
+            var @default = attr.Default;
+            if (@default.IsNullOrDefault())
+            {
+                return null;
+            }
+
+            if (typeof(T) == typeof(short))
+            {
+                return new OpenApiInteger((short) @default);
+            }
+
+            if (typeof(T) == typeof(int))
+            {
+                return new OpenApiInteger((int) @default);
+            }
+
+            if (typeof(T) == typeof(long))
+            {
                 return new OpenApiLong((long) @default);
+            }
+
+            if (@default is ushort)
+            {
+                return new OpenApiInteger(Convert.ToInt16(@default));
+            }
+
+            if (@default is uint)
+            {
+                return new OpenApiInteger(Convert.ToInt32(@default));
+            }
+
+            if (@default is ulong)
+            {
+                return new OpenApiLong(Convert.ToInt64(@default));
+            }
+
+            if (typeof(T) == typeof(string) && @default.GetType().IsEnumType())
+            {
+                var @enum = (Enum)Convert.ChangeType(@default, typeof(Enum));
+
+                return new OpenApiString((string) EnumExtensions.ToDisplayName(@enum));
             }
 
             return new OpenApiString((string) @default);

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks> -->
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 
@@ -29,6 +28,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.Fakes\Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.Fakes.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
+    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <!-- <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks> -->
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 
@@ -26,17 +27,17 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
+  <!-- <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
     <PackageReference Include="Castle.Core" Version="4.4.0" />
   </ItemGroup>
-
+ -->
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.Fakes\Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.Fakes.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
+  <!-- <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
     <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
+  </ItemGroup> -->
 
   <ItemGroup>
     <None Update="fakeconfig.json">

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.csproj
@@ -26,6 +26,10 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
+    <PackageReference Include="Castle.Core" Version="4.4.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.Fakes\Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.Fakes.csproj" />
   </ItemGroup>

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.AppSettings.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <!-- <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks> -->
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.CLI.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.CLI.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.CLI.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.CLI.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 
@@ -31,7 +31,7 @@
     <ProjectReference Include="..\Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes\Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'!='netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.csproj
@@ -29,7 +29,7 @@
     <ProjectReference Include="..\Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes\Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'!='netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/BooleanTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/BooleanTypeVisitorTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(bool));
@@ -95,6 +95,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, true, "lorem ipsum")]
+        [DataRow("hello", true, false, "lorem ipsum")]
+        [DataRow("hello", false, true, "lorem ipsum")]
+        [DataRow("hello", false, false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, object @default, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(bool));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Default = @default, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().NotBeNull();
+            (acceptor.Schemas[name].Default as OpenApiBoolean).Value.Should().Be((bool)@default);
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DateTimeOffsetObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DateTimeOffsetObjectTypeVisitorTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(DateTimeOffset));
@@ -95,6 +95,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_With_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var @default = DateTimeOffset.UtcNow;
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(DateTimeOffset));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Default = @default, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().NotBeNull();
+            (acceptor.Schemas[name].Default as OpenApiDateTime).Value.Should().Be(@default);
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_Without_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(DateTimeOffset));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DateTimeTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DateTimeTypeVisitorTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(DateTime));
@@ -95,6 +95,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_With_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var @default = DateTime.UtcNow;
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(DateTime));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Default = @default, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().NotBeNull();
+            (acceptor.Schemas[name].Default as OpenApiDateTime).Value.Should().Be(@default);
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_Without_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(DateTime));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DecimalTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DecimalTypeVisitorTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(decimal));
@@ -95,6 +95,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_With_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var @default = 1.0M;
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(decimal));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Default = @default, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().NotBeNull();
+            (acceptor.Schemas[name].Default as OpenApiDouble).Value.Should().Be(Convert.ToDouble(@default));
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_Without_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(decimal));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DictionaryObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DictionaryObjectTypeVisitorTests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(Dictionary<string, string>));
@@ -125,6 +125,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DoubleTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DoubleTypeVisitorTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(double));
@@ -95,6 +95,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_With_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var @default = 1.0;
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(double));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Default = @default, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().NotBeNull();
+            (acceptor.Schemas[name].Default as OpenApiDouble).Value.Should().Be(@default);
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_Without_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(double));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/GuidObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/GuidObjectTypeVisitorTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(Guid));
@@ -95,6 +95,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_With_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var @default = Guid.NewGuid();
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(Guid));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Default = @default, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().NotBeNull();
+            (acceptor.Schemas[name].Default as OpenApiString).Value.Should().Be(@default.ToString());
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_Without_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(Guid));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int16EnumTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int16EnumTypeVisitorTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(FakeShortEnum));
@@ -107,6 +107,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_With_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var @default = FakeShortEnum.ShortValue1;
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(FakeShortEnum));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Default = @default, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().NotBeNull();
+            (acceptor.Schemas[name].Default as OpenApiInteger).Value.Should().Be((short)@default);
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_Without_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(FakeShortEnum));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int16TypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int16TypeVisitorTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(short));
@@ -95,6 +95,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_With_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var @default = (short)1;
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(short));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Default = @default, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().NotBeNull();
+            (acceptor.Schemas[name].Default as OpenApiInteger).Value.Should().Be((short)@default);
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_Without_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(short));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int32EnumTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int32EnumTypeVisitorTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(FakeIntEnum));
@@ -107,6 +107,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_With_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var @default = FakeIntEnum.IntValue1;
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(FakeIntEnum));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Default = @default, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().NotBeNull();
+            (acceptor.Schemas[name].Default as OpenApiInteger).Value.Should().Be((int)@default);
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_Without_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(FakeIntEnum));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int32TypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int32TypeVisitorTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(int));
@@ -95,6 +95,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_With_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var @default = 1;
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(int));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Default = @default, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().NotBeNull();
+            (acceptor.Schemas[name].Default as OpenApiInteger).Value.Should().Be(@default);
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_Without_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(int));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int64EnumTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int64EnumTypeVisitorTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(FakeLongEnum));
@@ -107,6 +107,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_With_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var @default = FakeLongEnum.LongValue1;
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(FakeLongEnum));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Default = @default, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().NotBeNull();
+            (acceptor.Schemas[name].Default as OpenApiLong).Value.Should().Be((long)@default);
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_Without_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(FakeLongEnum));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int64TypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int64TypeVisitorTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(long));
@@ -95,6 +95,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_With_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var @default = (long)1;
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(long));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Default = @default, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().NotBeNull();
+            (acceptor.Schemas[name].Default as OpenApiLong).Value.Should().Be(@default);
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_Without_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(long));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/JObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/JObjectTypeVisitorTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(JObject));
@@ -102,6 +102,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/ListObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/ListObjectTypeVisitorTests.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(List<string>));
@@ -135,6 +135,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/NullableObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/NullableObjectTypeVisitorTests.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow(typeof(DateTime?), false)]
+        [DataRow(typeof(string), false)]
         public void Given_Type_When_IsNavigatable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
         {
             var result = this._visitor.IsNavigatable(type);
@@ -89,7 +90,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(DateTime?));
@@ -97,6 +98,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow(typeof(DateTime?), true, "hello", "lorem ipsum")]
+        [DataRow(typeof(int?), true, "hello", "lorem ipsum")]
+        [DataRow(typeof(DateTime?), false, "hello", "lorem ipsum")]
+        [DataRow(typeof(int?), false, "hello", "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(Type objectType, bool nullable, string name, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, objectType);
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/ObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/ObjectTypeVisitorTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(FakeModel));
@@ -116,6 +116,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/RecursiveObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/RecursiveObjectTypeVisitorTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(FakeRecursiveModel));
@@ -104,6 +104,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/SingleTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/SingleTypeVisitorTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(float));
@@ -95,6 +95,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_With_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var @default = 1.0f;
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(float));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Default = @default, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().NotBeNull();
+            (acceptor.Schemas[name].Default as OpenApiFloat).Value.Should().Be(@default);
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_Without_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(float));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/StringEnumTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/StringEnumTypeVisitorTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(FakeStringEnum));
@@ -107,6 +107,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_With_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var @default = FakeStringEnum.StringValue1;
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(FakeStringEnum));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Default = @default, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().NotBeNull();
+            (acceptor.Schemas[name].Default as OpenApiString).Value.Should().Be(@default.ToDisplayName());
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_Without_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(FakeLongEnum));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/StringTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/StringTypeVisitorTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(string));
@@ -95,6 +95,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt16TypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt16TypeVisitorTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(ushort));
@@ -98,6 +98,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_With_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var @default = (ushort)1;
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(ushort));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Default = @default, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().NotBeNull();
+            (acceptor.Schemas[name].Default as OpenApiInteger).Value.Should().Be((ushort)@default);
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_Without_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(ushort));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt32TypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt32TypeVisitorTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(uint));
@@ -98,6 +98,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_With_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var @default = (uint)1;
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(uint));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Default = @default, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().NotBeNull();
+            (acceptor.Schemas[name].Default as OpenApiInteger).Value.Should().Be((int)@default);
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_Without_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(uint));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt64TypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt64TypeVisitorTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(ulong));
@@ -98,6 +98,42 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_With_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var @default = (ulong)1;
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(ulong));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Default = @default, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().NotBeNull();
+            (acceptor.Schemas[name].Default as OpenApiLong).Value.Should().Be((long)@default);
+            acceptor.Schemas[name].Description.Should().Be(description);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello", true, "lorem ipsum")]
+        [DataRow("hello", false, "lorem ipsum")]
+        public void Given_OpenApiPropertyAttribute_Without_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+        {
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(ulong));
+            var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Description = description };
+
+            this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+            acceptor.Schemas[name].Nullable.Should().Be(nullable);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UriTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UriTypeVisitorTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow("hello", "lorem ipsum")]
-        public void Given_OpenApiPropertyDescriptionAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+        public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
         {
             var acceptor = new OpenApiSchemaAcceptor();
             var type = new KeyValuePair<string, Type>(name, typeof(Uri));
@@ -95,6 +95,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             this._visitor.Visit(acceptor, type, this._strategy, attribute);
 
+            acceptor.Schemas[name].Nullable.Should().Be(false);
+            acceptor.Schemas[name].Default.Should().BeNull();
             acceptor.Schemas[name].Description.Should().Be(description);
         }
 


### PR DESCRIPTION
This PR is to support the `string?` property.

As this package MUST consider backward compatibility, it can't explicitly declare using C# 8+. Therefore, the `string?` property can't be supported out-of-the-box. However, with the `OpenApiPropertyAttribute` class, the `nullable` property can be explicitly declared in C# 7.x.
