### PR TITLE
Refactor DefaultOpenApiConfigurationOptions

### DIFF
--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/Configurations/OpenApiConfigurationOptions.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/Configurations/OpenApiConfigurationOptions.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static.Config
     {
         public override OpenApiInfo Info { get; set; } = new OpenApiInfo()
         {
-            Version = "3.0.0",
-            Title = "OpenAPI Sample on Azure Functions (STATIC)",
+            Version = GetOpenApiDocVersion(),
+            Title = GetOpenApiDocTitle(typeof(OpenApiConfigurationOptions)),
             Description = "A sample API that runs on Azure Functions (STATIC) 3.x using OpenAPI specification.",
             TermsOfService = new Uri("https://github.com/Azure/azure-functions-openapi-extension"),
             Contact = new OpenApiContact()
@@ -27,6 +27,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static.Config
             }
         };
 
-        public override OpenApiVersionType OpenApiVersion { get; set; } = OpenApiVersionType.V3;
+        public override OpenApiVersionType OpenApiVersion { get; set; } = GetOpenApiVersion();
     }
 }

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/local.settings.json
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/local.settings.json
@@ -6,6 +6,9 @@
 
     "AZURE_FUNCTION_PROXY_DISABLE_LOCAL_CALL": "true",
 
+    "OpenApi__Version": "v3",
+    "OpenApi__DocVersion": "3.0.0",
+    "OpenApi__DocTitle": "OpenAPI Sample on Azure Functions (STATIC)",
     "OpenApi__HideSwaggerUI": "false",
     "OpenApi__ApiKey": "",
     "OpenApi__AuthLevel__Document": "Anonymous",

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
     /// </summary>
     public class DefaultOpenApiConfigurationOptions : IOpenApiConfigurationOptions
     {
-        private const string FunctionsRuntimeEnvironmentKey = "AZURE_FUNCTIONS_ENVIRONMENT";
-        private const string OpenApiVersionKey = "OpenApi__Version";
         private const string OpenApiDocVersionKey = "OpenApi__DocVersion";
         private const string OpenApiDocTitleKey = "OpenApi__DocTitle";
         private const string OpenApiHostNamesKey = "OpenApi__HostNames";
+        private const string OpenApiVersionKey = "OpenApi__Version";
+        private const string FunctionsRuntimeEnvironmentKey = "AZURE_FUNCTIONS_ENVIRONMENT";
 
         /// <inheritdoc />
         public virtual OpenApiInfo Info { get; set; } = new OpenApiInfo()
@@ -36,6 +36,29 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
 
         /// <inheritdoc />
         public virtual bool IncludeRequestingHostName { get; set; } = IsFunctionsRuntimeEnvironmentDevelopment();
+
+        /// <summary>
+        /// Gets the OpenAPI document version.
+        /// </summary>
+        /// <returns>Returns the OpenAPI document version.</returns>
+        protected static string GetOpenApiDocVersion()
+        {
+            var version = Environment.GetEnvironmentVariable(OpenApiDocVersionKey) ?? DefaultOpenApiDocVersion();
+
+            return version;
+        }
+
+        /// <summary>
+        /// Gets the OpenAPI document title.
+        /// </summary>
+        /// <param name="type">Type to get the title.</param>
+        /// <returns>Returns the OpenAPI document title.</returns>
+        protected static string GetOpenApiDocTitle(Type type = null)
+        {
+            var title = Environment.GetEnvironmentVariable(OpenApiDocTitleKey) ?? DefaultOpenApiDocTitle(type);
+
+            return title;
+        }
 
         /// <summary>
         /// Gets the list of hostnames.
@@ -73,25 +96,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
         }
 
         /// <summary>
-        /// Gets the OpenAPI document version.
+        /// Checks whether the current Azure Functions runtime environment is "Development" or not.
         /// </summary>
-        /// <returns>Returns the OpenAPI document version.</returns>
-        protected static string GetOpenApiDocVersion()
+        /// <returns>Returns <c>True</c>, if the current Azure Functions runtime environment is "Development"; otherwise returns <c>False</c></returns>
+        protected static bool IsFunctionsRuntimeEnvironmentDevelopment()
         {
-            var version = Environment.GetEnvironmentVariable(OpenApiDocVersionKey) ?? DefaultOpenApiDocVersion();
+            var development = Environment.GetEnvironmentVariable(FunctionsRuntimeEnvironmentKey) == "Development";
 
-            return version;
-        }
-
-        /// <summary>
-        /// Gets the OpenAPI document title.
-        /// </summary>
-        /// <returns>Returns the OpenAPI document title.</returns>
-        protected static string GetOpenApiDocTitle()
-        {
-            var title = Environment.GetEnvironmentVariable(OpenApiDocTitleKey) ?? DefaultOpenApiDocTitle(typeof(DefaultOpenApiConfigurationOptions));
-
-            return title;
+            return development;
         }
 
         private static OpenApiVersionType DefaultOpenApiVersion()
@@ -104,18 +116,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
             return "1.0.0";
         }
 
-        private static string DefaultOpenApiDocTitle(Type type)
+        private static string DefaultOpenApiDocTitle(Type type = null)
         {
+            if (type == null)
+            {
+                type = typeof(DefaultOpenApiConfigurationOptions);
+            }
+
             var assembly = Assembly.GetAssembly(type);
 
             return assembly.GetName().Name;
-        }
-
-        private static bool IsFunctionsRuntimeEnvironmentDevelopment()
-        {
-            var development = Environment.GetEnvironmentVariable(FunctionsRuntimeEnvironmentKey) == "Development";
-
-            return development;
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
@@ -14,21 +15,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
     /// </summary>
     public class DefaultOpenApiConfigurationOptions : IOpenApiConfigurationOptions
     {
+        private const string FunctionsRuntimeEnvironmentKey = "AZURE_FUNCTIONS_ENVIRONMENT";
+        private const string OpenApiVersionKey = "OpenApi__Version";
+        private const string OpenApiDocVersionKey = "OpenApi__DocVersion";
+        private const string OpenApiDocTitleKey = "OpenApi__DocTitle";
+        private const string OpenApiHostNamesKey = "OpenApi__HostNames";
+
         /// <inheritdoc />
         public virtual OpenApiInfo Info { get; set; } = new OpenApiInfo()
         {
-            Version = "1.0.0",
-            Title = "Azure Functions OpenAPI Extension",
+            Version = GetOpenApiDocVersion(),
+            Title = GetOpenApiDocTitle(),
         };
 
         /// <inheritdoc />
         public virtual List<OpenApiServer> Servers { get; set; } = GetHostNames();
 
         /// <inheritdoc />
-        public virtual OpenApiVersionType OpenApiVersion { get; set; } = OpenApiVersionType.V2;
+        public virtual OpenApiVersionType OpenApiVersion { get; set; } = GetOpenApiVersion();
 
         /// <inheritdoc />
-        public virtual bool IncludeRequestingHostName { get; set; } = Environment.GetEnvironmentVariable("AZURE_FUNCTIONS_ENVIRONMENT") == "Development";
+        public virtual bool IncludeRequestingHostName { get; set; } = IsFunctionsRuntimeEnvironmentDevelopment();
 
         /// <summary>
         /// Gets the list of hostnames.
@@ -37,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
         protected static List<OpenApiServer> GetHostNames()
         {
             var servers = new List<OpenApiServer>();
-            var collection = Environment.GetEnvironmentVariable("OpenApi__HostNames");
+            var collection = Environment.GetEnvironmentVariable(OpenApiHostNamesKey);
             if (collection.IsNullOrWhiteSpace())
             {
                 return servers;
@@ -49,6 +56,66 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
             servers.AddRange(hostnames);
 
             return servers;
+        }
+
+        /// <summary>
+        /// Gets the OpenAPI version.
+        /// </summary>
+        /// <returns>Returns the OpenAPI version.</returns>
+        protected static OpenApiVersionType GetOpenApiVersion()
+        {
+            var version = Enum.TryParse<OpenApiVersionType>(
+                              Environment.GetEnvironmentVariable(OpenApiVersionKey), ignoreCase: true, out var result)
+                            ? result
+                            : DefaultOpenApiVersion();
+
+            return version;
+        }
+
+        /// <summary>
+        /// Gets the OpenAPI document version.
+        /// </summary>
+        /// <returns>Returns the OpenAPI document version.</returns>
+        protected static string GetOpenApiDocVersion()
+        {
+            var version = Environment.GetEnvironmentVariable(OpenApiDocVersionKey) ?? DefaultOpenApiDocVersion();
+
+            return version;
+        }
+
+        /// <summary>
+        /// Gets the OpenAPI document title.
+        /// </summary>
+        /// <returns>Returns the OpenAPI document title.</returns>
+        protected static string GetOpenApiDocTitle()
+        {
+            var title = Environment.GetEnvironmentVariable(OpenApiDocTitleKey) ?? DefaultOpenApiDocTitle(typeof(DefaultOpenApiConfigurationOptions));
+
+            return title;
+        }
+
+        private static OpenApiVersionType DefaultOpenApiVersion()
+        {
+            return OpenApiVersionType.V2;
+        }
+
+        private static string DefaultOpenApiDocVersion()
+        {
+            return "1.0.0";
+        }
+
+        private static string DefaultOpenApiDocTitle(Type type)
+        {
+            var assembly = Assembly.GetAssembly(type);
+
+            return assembly.GetName().Name;
+        }
+
+        private static bool IsFunctionsRuntimeEnvironmentDevelopment()
+        {
+            var development = Environment.GetEnvironmentVariable(FunctionsRuntimeEnvironmentKey) == "Development";
+
+            return development;
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/DefaultOpenApiConfigurationOptionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/DefaultOpenApiConfigurationOptionsTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
 
             settings.Info.Should().NotBeNull();
             settings.Info.Version.Should().Be("1.0.0");
-            settings.Info.Title.Should().Be("Azure Functions OpenAPI Extension");
+            settings.Info.Title.Should().Be(typeof(DefaultOpenApiConfigurationOptions).GetTypeInfo().Assembly.GetName().Name);
 
             settings.Servers.Should().NotBeNull();
             settings.Servers.Should().HaveCount(0);

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/DefaultOpenApiConfigurationOptionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/DefaultOpenApiConfigurationOptionsTests.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using FluentAssertions;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.OpenApi.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -17,17 +18,78 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
         [TestMethod]
         public void Given_Type_When_Instantiated_Then_Properties_Should_Return_Value()
         {
-            var settings = new DefaultOpenApiConfigurationOptions();
+            var options = new DefaultOpenApiConfigurationOptions();
 
-            settings.Info.Should().NotBeNull();
-            settings.Info.Version.Should().Be("1.0.0");
-            settings.Info.Title.Should().Be(typeof(DefaultOpenApiConfigurationOptions).GetTypeInfo().Assembly.GetName().Name);
+            options.Info.Should().NotBeNull();
+            options.Info.Version.Should().Be("1.0.0");
+            options.Info.Title.Should().Be(typeof(DefaultOpenApiConfigurationOptions).GetTypeInfo().Assembly.GetName().Name);
 
-            settings.Servers.Should().NotBeNull();
-            settings.Servers.Should().HaveCount(0);
+            options.Servers.Should().NotBeNull();
+            options.Servers.Should().HaveCount(0);
 
-            settings.OpenApiVersion.Should().Be(OpenApiVersionType.V2);
-            settings.IncludeRequestingHostName.Should().BeFalse();
+            options.OpenApiVersion.Should().Be(OpenApiVersionType.V2);
+            options.IncludeRequestingHostName.Should().BeFalse();
+        }
+
+        [DataTestMethod]
+        [DataRow(null, "1.0.0")]
+        [DataRow("", "1.0.0")]
+        [DataRow("v1.0", "v1.0")]
+        [DataRow("1.0", "1.0")]
+        public void Given_OpenApiDocVersion_When_Instantiated_Then_Property_Should_Return_Value(string version, string expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__DocVersion", version);
+
+            var options = new DefaultOpenApiConfigurationOptions();
+
+            options.Info.Version.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow("hello world")]
+        public void Given_OpenApiDocTitle_When_Instantiated_Then_Property_Should_Return_Value(string title)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__DocTitle", title);
+
+            var expected = title.IsNullOrWhiteSpace()
+                               ? typeof(DefaultOpenApiConfigurationOptions).GetTypeInfo().Assembly.GetName().Name
+                               : title;
+
+            var options = new DefaultOpenApiConfigurationOptions();
+
+            options.Info.Title.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, 0)]
+        [DataRow("", 0)]
+        [DataRow("https://localhost", 1)]
+        [DataRow("https://localhost,https://loremipsum", 2)]
+        public void Given_HostNames_When_Instantiated_Then_Property_Should_Return_Value(string hostnames, int expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__HostNames", hostnames);
+
+            var options = new DefaultOpenApiConfigurationOptions();
+
+            options.Servers.Should().HaveCount(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, OpenApiVersionType.V2)]
+        [DataRow("", OpenApiVersionType.V2)]
+        [DataRow("v2", OpenApiVersionType.V2)]
+        [DataRow("V2", OpenApiVersionType.V2)]
+        [DataRow("v3", OpenApiVersionType.V3)]
+        [DataRow("V3", OpenApiVersionType.V3)]
+        public void Given_OpenApiVersion_When_Instantiated_Then_Property_Should_Return_Value(string version, OpenApiVersionType expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__Version", version);
+
+            var options = new DefaultOpenApiConfigurationOptions();
+
+            options.OpenApiVersion.Should().Be(expected);
         }
 
         [DataTestMethod]
@@ -37,9 +99,48 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
         {
             Environment.SetEnvironmentVariable("AZURE_FUNCTIONS_ENVIRONMENT", environment);
 
-            var settings = new DefaultOpenApiConfigurationOptions();
+            var options = new DefaultOpenApiConfigurationOptions();
 
-            settings.IncludeRequestingHostName.Should().Be(expected);
+            options.IncludeRequestingHostName.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, "1.0.0")]
+        [DataRow("", "1.0.0")]
+        [DataRow("v1.0", "v1.0")]
+        [DataRow("1.0", "1.0")]
+        public void Given_EnvironmentVariable_When_GetOpenApiDocVersion_Invoked_Then_It_Should_Return_Result(string version, string expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__DocVersion", version);
+
+            var options = new DefaultOpenApiConfigurationOptions();
+            var method = typeof(DefaultOpenApiConfigurationOptions).GetMethod("GetOpenApiDocVersion", BindingFlags.NonPublic | BindingFlags.Static);
+
+            var result = method.Invoke(options, null);
+
+            result.Should().BeOfType<string>();
+            (result as string).Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow("hello world")]
+        public void Given_EnvironmentVariable_When_GetOpenApiDocTitle_Invoked_Then_It_Should_Return_Result(string title)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__DocTitle", title);
+
+            var expected = title.IsNullOrWhiteSpace()
+                               ? typeof(DefaultOpenApiConfigurationOptions).GetTypeInfo().Assembly.GetName().Name
+                               : title;
+
+            var options = new DefaultOpenApiConfigurationOptions();
+            var method = typeof(DefaultOpenApiConfigurationOptions).GetMethod("GetOpenApiDocTitle", BindingFlags.NonPublic | BindingFlags.Static);
+
+            var result = method.Invoke(options, new[] { (Type)null });
+
+            result.Should().BeOfType<string>();
+            (result as string).Should().Be(expected);
         }
 
         [DataTestMethod]
@@ -51,13 +152,49 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
         {
             Environment.SetEnvironmentVariable("OpenApi__HostNames", hostnames);
 
-            var settings = new DefaultOpenApiConfigurationOptions();
+            var options = new DefaultOpenApiConfigurationOptions();
             var method = typeof(DefaultOpenApiConfigurationOptions).GetMethod("GetHostNames", BindingFlags.NonPublic | BindingFlags.Static);
 
-            var result = method.Invoke(settings, null);
+            var result = method.Invoke(options, null);
 
             result.Should().BeOfType<List<OpenApiServer>>();
             (result as List<OpenApiServer>).Should().HaveCount(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, OpenApiVersionType.V2)]
+        [DataRow("", OpenApiVersionType.V2)]
+        [DataRow("v2", OpenApiVersionType.V2)]
+        [DataRow("V2", OpenApiVersionType.V2)]
+        [DataRow("v3", OpenApiVersionType.V3)]
+        [DataRow("V3", OpenApiVersionType.V3)]
+        public void Given_EnvironmentVariable_When_GetHostNames_Invoked_Then_It_Should_Return_Result(string version, OpenApiVersionType expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__Version", version);
+
+            var options = new DefaultOpenApiConfigurationOptions();
+            var method = typeof(DefaultOpenApiConfigurationOptions).GetMethod("GetOpenApiVersion", BindingFlags.NonPublic | BindingFlags.Static);
+
+            var result = method.Invoke(options, null);
+
+            result.Should().BeOfType<OpenApiVersionType>();
+            ((OpenApiVersionType)result).Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow("Development", true)]
+        [DataRow("Production", false)]
+        public void Given_EnvironmentVariable_When_GetHostNames_Invoked_Then_It_Should_Return_Result(string environment, bool expected)
+        {
+            Environment.SetEnvironmentVariable("AZURE_FUNCTIONS_ENVIRONMENT", environment);
+
+            var options = new DefaultOpenApiConfigurationOptions();
+            var method = typeof(DefaultOpenApiConfigurationOptions).GetMethod("IsFunctionsRuntimeEnvironmentDevelopment", BindingFlags.NonPublic | BindingFlags.Static);
+
+            var result = method.Invoke(options, null);
+
+            result.Should().BeOfType<bool>();
+            ((bool)result).Should().Be(expected);
         }
     }
 }


### PR DESCRIPTION
This change is to read from environment variables for OpenAPI version, document version and document title.