### PR TITLE
Removing naming strategy when documenting enum values

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
                 throw new InvalidOperationException("Scheme MUST be provided");
             }
 
-            return attr.Scheme.ToDisplayName(namingStrategy);
+            return attr.Scheme.ToDisplayName();
         }
 
         private static string GetSecurityBearerFormat(OpenApiSecurityAttribute attr)

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/EnumExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/EnumExtensions.cs
@@ -17,30 +17,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
         /// Gets the display name of the enum value.
         /// </summary>
         /// <param name="enum">Enum value.</param>
-        /// <param name="namingStrategy"><see cref="NamingStrategy"/> instance.</param>
+        /// 
         /// <returns>Display name of the enum value.</returns>
-        public static string ToString(this Enum @enum, NamingStrategy namingStrategy = null)
+        public static string ToString(this Enum @enum)
         {
-            return @enum.ToDisplayName(namingStrategy);
+            return @enum.ToDisplayName();
         }
 
         /// <summary>
         /// Gets the display name of the enum value.
         /// </summary>
         /// <param name="enum">Enum value.</param>
-        /// <param name="namingStrategy"><see cref="NamingStrategy"/> instance.</param>
+        /// 
         /// <returns>Display name of the enum value.</returns>
-        public static string ToDisplayName(this Enum @enum, NamingStrategy namingStrategy = null)
+        public static string ToDisplayName(this Enum @enum)
         {
-            if (namingStrategy.IsNullOrDefault())
-            {
-                namingStrategy = new DefaultNamingStrategy();
-            }
-
             var type = @enum.GetType();
             var member = type.GetMember(@enum.ToString()).First();
 
-            return member.ToDisplayName(namingStrategy);
+            return member.ToDisplayName();
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/MemberInfoExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/MemberInfoExtensions.cs
@@ -33,28 +33,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
         /// Gets the display name of the enum value.
         /// </summary>
         /// <param name="element"><see cref="MemberInfo"/> instance.</param>
-        /// <param name="namingStrategy"><see cref="NamingStrategy"/> instance.</param>
+        /// 
         /// <returns>Display name of the enum value.</returns>
-        public static string ToDisplayName(this MemberInfo element, NamingStrategy namingStrategy = null)
+        public static string ToDisplayName(this MemberInfo element)
         {
-            element.ThrowIfNullOrDefault();
-
-            if (namingStrategy.IsNullOrDefault())
-            {
-                namingStrategy = new DefaultNamingStrategy();
-            }
+            _ = element.ThrowIfNullOrDefault();
 
             var displayAttribute = element.GetCustomAttribute<DisplayAttribute>(inherit: false);
             var enumMemberAttribute = element.GetCustomAttribute<EnumMemberAttribute>(inherit: false);
 
             // EnumMemberAttribute takes precedence to DisplayAttribute
-            var name = !enumMemberAttribute.IsNullOrDefault()
+            return !enumMemberAttribute.IsNullOrDefault()
                        ? enumMemberAttribute.Value
                        : (!displayAttribute.IsNullOrDefault()
                           ? displayAttribute.Name
                           : element.Name);
-
-            return namingStrategy.GetPropertyName(name, hasSpecifiedName: false);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
             // namingStrategy null check
 
             var members = type.GetMembers(BindingFlags.Public | BindingFlags.Static);
-            var names = members.Select(p => p.ToDisplayName(namingStrategy));
+            var names = members.Select(p => p.ToDisplayName());
 
             return names.Select(p => (IOpenApiAny)new OpenApiString(p))
                         .ToList();

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/MemberInfoExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/MemberInfoExtensionsTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
         [TestMethod]
         public void Given_Null_When_ToDisplayName_Invoked_Then_It_Should_Throw_Exception()
         {
-            Action action = () => MemberInfoExtensions.ToDisplayName(null, null);
+            Action action = () => MemberInfoExtensions.ToDisplayName(null);
 
             action.Should().Throw<ArgumentNullException>();
         }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/BooleanTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/BooleanTypeVisitorTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DateTimeOffsetObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DateTimeOffsetObjectTypeVisitorTests.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DateTimeTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DateTimeTypeVisitorTests.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DecimalTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DecimalTypeVisitorTests.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DictionaryObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DictionaryObjectTypeVisitorTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DoubleTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DoubleTypeVisitorTests.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/GuidObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/GuidObjectTypeVisitorTests.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int16EnumTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int16EnumTypeVisitorTests.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int16TypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int16TypeVisitorTests.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int32EnumTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int32EnumTypeVisitorTests.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int32TypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int32TypeVisitorTests.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int64EnumTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int64EnumTypeVisitorTests.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int64TypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/Int64TypeVisitorTests.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/JObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/JObjectTypeVisitorTests.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/ListObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/ListObjectTypeVisitorTests.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/NullableObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/NullableObjectTypeVisitorTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/ObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/ObjectTypeVisitorTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/RecursiveObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/RecursiveObjectTypeVisitorTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/SingleTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/SingleTypeVisitorTests.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/StringEnumTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/StringEnumTypeVisitorTests.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/StringTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/StringTypeVisitorTests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt16TypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt16TypeVisitorTests.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt32TypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt32TypeVisitorTests.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt64TypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UInt64TypeVisitorTests.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UriTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/UriTypeVisitorTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
             acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
             acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
-            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+            (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName());
         }
 
         [DataTestMethod]


### PR DESCRIPTION
See https://github.com/Azure/azure-functions-openapi-extension/issues/170

The current implementation, which changes the casing of enum values, is confusing our API clients.