### PR TITLE
Add extension for QueryCollection

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Extensions/HttpRequestDataExtensions.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Extensions/HttpRequestDataExtensions.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Internal;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Extensions
+{
+    /// <summary>
+    /// This represents the extension entity for <see cref="HttpRequestData"/>.
+    /// </summary>
+    public static class HttpRequestDataExtensions
+    {
+        /// <summary>
+        /// Gets the <see cref="QueryCollection"/> instance from the <see cref="HttpRequestData"/>.
+        /// </summary>
+        /// <param name="req"><see cref="HttpRequestData"/> instance.</param>
+        /// <returns>Returns <see cref="QueryCollection"/> instance.</returns>
+        public static IQueryCollection Queries(this HttpRequestData req)
+        {
+            var queries = QueryHelpers.ParseNullableQuery(req.Url.Query);
+            if (queries.IsNullOrDefault())
+            {
+                queries = new Dictionary<string, StringValues>();
+            }
+
+            return new QueryCollection(queries);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="StringValues"/> object from the <see cref="HttpRequestData"/>.
+        /// </summary>
+        /// <param name="req"><see cref="HttpRequestData"/> instance.</param>
+        /// <param name="key">Querystring key.</param>
+        /// <returns>Returns <see cref="StringValues"/> object.</returns>
+        public static StringValues Query(this HttpRequestData req, string key)
+        {
+            var queries = Queries(req);
+            var value = queries.ContainsKey(key) ? queries[key] : new StringValues(default(string));
+
+            return value;
+        }
+    }
+}

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Extensions/OpenApiHttpRequestDataExtensions.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Extensions/OpenApiHttpRequestDataExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Extensions
     /// <summary>
     /// This represents the extension entity for <see cref="HttpRequestData"/>.
     /// </summary>
-    public static class HttpRequestDataExtensions
+    public static class OpenApiHttpRequestDataExtensions
     {
         /// <summary>
         /// Gets the <see cref="QueryCollection"/> instance from the <see cref="HttpRequestData"/>.
@@ -21,6 +21,8 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Extensions
         /// <returns>Returns <see cref="QueryCollection"/> instance.</returns>
         public static IQueryCollection Queries(this HttpRequestData req)
         {
+            req.ThrowIfNullOrDefault();
+
             var queries = QueryHelpers.ParseNullableQuery(req.Url.Query);
             if (queries.IsNullOrDefault())
             {
@@ -38,6 +40,8 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Extensions
         /// <returns>Returns <see cref="StringValues"/> object.</returns>
         public static StringValues Query(this HttpRequestData req, string key)
         {
+            req.ThrowIfNullOrDefault();
+
             var queries = Queries(req);
             var value = queries.ContainsKey(key) ? queries[key] : new StringValues(default(string));
 

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/Extensions/HttpRequestDataExtensionsTests.cs
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/Extensions/HttpRequestDataExtensionsTests.cs
@@ -1,0 +1,133 @@
+using System;
+
+using FluentAssertions;
+
+using Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Extensions;
+using Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Fakes;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
+{
+    [TestClass]
+    public class HttpRequestDataExtensionsTests
+    {
+        [TestMethod]
+        public void Given_Null_When_Queries_Invoked_Then_It_Should_Throw_Exception()
+        {
+            Action action = () => OpenApiHttpRequestDataExtensions.Queries(null);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void Given_NullQuerystring_When_Queries_Invoked_Then_It_Should_Return_Result()
+        {
+            var context = new Mock<FunctionContext>();
+
+            var baseHost = "localhost";
+            var uri = Uri.TryCreate($"http://{baseHost}", UriKind.Absolute, out var tried) ? tried : null;
+
+            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri);
+
+            var result = OpenApiHttpRequestDataExtensions.Queries(req);
+
+            result.Count.Should().Be(0);
+       }
+
+        [DataTestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        public void Given_NoQuerystring_When_Queries_Invoked_Then_It_Should_Return_Result(string querystring)
+        {
+            var context = new Mock<FunctionContext>();
+
+            var baseHost = "localhost";
+            var uri = Uri.TryCreate($"http://{baseHost}?{querystring}", UriKind.Absolute, out var tried) ? tried : null;
+
+            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri);
+
+            var result = OpenApiHttpRequestDataExtensions.Queries(req);
+
+            result.Count.Should().Be(0);
+       }
+
+        [DataTestMethod]
+        [DataRow("hello=world", "hello")]
+        [DataRow("hello=world&lorem=ipsum", "hello", "lorem")]
+        public void Given_Querystring_When_Queries_Invoked_Then_It_Should_Return_Result(string querystring, params string[] keys)
+        {
+            var context = new Mock<FunctionContext>();
+
+            var baseHost = "localhost";
+            var uri = Uri.TryCreate($"http://{baseHost}?{querystring}", UriKind.Absolute, out var tried) ? tried : null;
+
+            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri);
+
+            var result = OpenApiHttpRequestDataExtensions.Queries(req);
+
+            result.Count.Should().Be(keys.Length);
+            result.Keys.Should().Contain(keys);
+        }
+
+        [TestMethod]
+        public void Given_Null_When_Query_Invoked_Then_It_Should_Throw_Exception()
+        {
+            Action action = () => OpenApiHttpRequestDataExtensions.Query(null, null);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [DataTestMethod]
+        [DataRow("hello=world", "hello", "world")]
+        [DataRow("hello=world&lorem=ipsum", "hello", "world")]
+        [DataRow("hello=world&lorem=ipsum", "lorem", "ipsum")]
+        public void Given_Querystring_When_Query_Invoked_Then_It_Should_Return_Result(string querystring, string key, string expected)
+        {
+            var context = new Mock<FunctionContext>();
+
+            var baseHost = "localhost";
+            var uri = Uri.TryCreate($"http://{baseHost}?{querystring}", UriKind.Absolute, out var tried) ? tried : null;
+
+            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri);
+
+            var result = (string) OpenApiHttpRequestDataExtensions.Query(req, key);
+
+            result.Should().Be(expected);
+        }
+
+        [TestMethod]
+        public void Given_NullQuerystring_When_Query_Invoked_Then_It_Should_Return_Result()
+        {
+            var context = new Mock<FunctionContext>();
+
+            var baseHost = "localhost";
+            var uri = Uri.TryCreate($"http://{baseHost}", UriKind.Absolute, out var tried) ? tried : null;
+
+            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri);
+
+            var result = (string) OpenApiHttpRequestDataExtensions.Query(req, "hello");
+
+            result.Should().BeNull();
+       }
+
+        [DataTestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        public void Given_NoQuerystring_When_Query_Invoked_Then_It_Should_Return_Result(string querystring)
+        {
+            var context = new Mock<FunctionContext>();
+
+            var baseHost = "localhost";
+            var uri = Uri.TryCreate($"http://{baseHost}?{querystring}", UriKind.Absolute, out var tried) ? tried : null;
+
+            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri);
+
+            var result = (string) OpenApiHttpRequestDataExtensions.Query(req, "hello");
+
+            result.Should().BeNull();
+       }
+    }
+}


### PR DESCRIPTION
This PR is to add two extension methods to deal with querystring, which is for **.NET 5 isolated worker**.

> **NOTE**: This feature will be deprecated when the core isolated worker introduces the same capability.

In in-proc worker, we're able to use `req.Query` to get the `IQueryCollection` instance. As there's no equivalent in the out-of-proc worker, this extension will do the same, with slightly different naming.

```csharp
public static async Task<HttpResponseData> Run(
    [HttpTrigger(AuthorizationLevel.Function, "GET")] HttpRequestData req,
    FunctionContext executionContext)
{
    // To get the whole IQueryCollection
    var queries = req.Queries();

    // To get the specific query parameter value.
    var value = (string) req.Query("key");

    ...
}
```