### PR TITLE
Tag filtering for Swagger UI and OpenAPI document

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,17 +1,17 @@
 {
-  "azureFunctions.deploySubpath": "samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5/bin/Release/net5.0/publish",
+  // "azureFunctions.deploySubpath": "samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5/bin/Release/net5.0/publish",
   // "azureFunctions.deploySubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V1Proxy/bin/Release/netcoreapp3.1/publish",
   // "azureFunctions.deploySubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC/bin/Release/netcoreapp2.1/publish",
   // "azureFunctions.deploySubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static/bin/Release/netcoreapp2.1/publish",
   // "azureFunctions.deploySubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/bin/Release/netcoreapp3.1/publish",
-  // "azureFunctions.deploySubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/bin/Release/netcoreapp3.1/publish",
+  "azureFunctions.deploySubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/bin/Release/netcoreapp3.1/publish",
 
-  "azureFunctions.projectSubpath": "samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5",
+  // "azureFunctions.projectSubpath": "samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5",
   // "azureFunctions.projectSubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V1Proxy",
   // "azureFunctions.projectSubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC",
   // "azureFunctions.projectSubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static",
   // "azureFunctions.projectSubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC",
-  // "azureFunctions.projectSubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static",
+  "azureFunctions.projectSubpath": "samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static",
 
   "azureFunctions.projectLanguage": "C#",
   "azureFunctions.projectRuntime": "~3",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,12 +12,6 @@
       "type": "process",
       "problemMatcher": "$msCompile",
       "options": {
-        "cwd": "${workspaceFolder}/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V1Proxy"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static"
       }
     },
     {
@@ -36,12 +30,6 @@
       },
       "problemMatcher": "$msCompile",
       "options": {
-        "cwd": "${workspaceFolder}/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V1Proxy"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static"
       }
     },
     {
@@ -57,12 +45,6 @@
       "type": "process",
       "problemMatcher": "$msCompile",
       "options": {
-        "cwd": "${workspaceFolder}/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V1Proxy"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static"
       }
     },
     {
@@ -79,12 +61,6 @@
       "dependsOn": "clean release",
       "problemMatcher": "$msCompile",
       "options": {
-        "cwd": "${workspaceFolder}/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V1Proxy"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static"
       }
     },
     {
@@ -104,12 +80,12 @@
       "type": "func",
       "dependsOn": "build",
       "options": {
-        "cwd": "${workspaceFolder}/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5/bin/Debug/net5.0"
+        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.V3Net5/bin/Debug/net5.0"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Proxy/bin/Debug/netcoreapp3.1"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2IoC/bin/Debug/netcoreapp2.1"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V2Static/bin/Debug/netcoreapp2.1"
         // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/bin/Debug/netcoreapp3.1"
-        // "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/bin/Debug/netcoreapp3.1"
+        "cwd": "${workspaceFolder}/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3Static/bin/Debug/netcoreapp3.1"
       },
       "command": "host start",
       "isBackground": true,

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Document.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Document.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi
 
         private NamingStrategy _strategy;
         private VisitorCollection _collection;
+        private IHttpRequestDataObject _req;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Document"/> class.
@@ -69,8 +70,10 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi
         /// <inheritdoc />
         public IDocument AddServer(IHttpRequestDataObject req, string routePrefix, IOpenApiConfigurationOptions options = null)
         {
+            this._req = req;
+
             var prefix = string.IsNullOrWhiteSpace(routePrefix) ? string.Empty : $"/{routePrefix}";
-            var baseUrl = $"{req.Scheme}://{req.Host}{prefix}";
+            var baseUrl = $"{this._req.Scheme}://{this._req.Host}{prefix}";
 
             var server = new OpenApiServer { Url = baseUrl };
 
@@ -135,7 +138,8 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi
 
             var paths = new OpenApiPaths();
 
-            var methods = this._helper.GetHttpTriggerMethods(assembly);
+            var tags = StringExtensions.ToArray(this._req.Query["tag"], ",");
+            var methods = this._helper.GetHttpTriggerMethods(assembly, tags);
             foreach (var method in methods)
             {
                 var trigger = this._helper.GetHttpTriggerAttribute(method);

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Extensions/DocumentHelperExtensions.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Extensions/DocumentHelperExtensions.cs
@@ -26,8 +26,9 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Extensions
         /// </summary>
         /// <param name="helper"><see cref="IDocumentHelper"/> instance.</param>
         /// <param name="assembly">Assembly of Azure Function instance.</param>
+        /// <param name="tags">List of tags to filter methods.</param>
         /// <returns>List of <see cref="MethodInfo"/> instances representing HTTP triggers.</returns>
-        public static List<MethodInfo> GetHttpTriggerMethods(this IDocumentHelper helper, Assembly assembly)
+        public static List<MethodInfo> GetHttpTriggerMethods(this IDocumentHelper helper, Assembly assembly, IEnumerable<string> tags = null)
         {
             var methods = assembly.GetLoadableTypes()
                                   .SelectMany(p => p.GetMethods())
@@ -36,6 +37,16 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Extensions
                                   .Where(p => !p.ExistsCustomAttribute<OpenApiIgnoreAttribute>())
                                   .Where(p => p.GetParameters().FirstOrDefault(q => q.ExistsCustomAttribute<HttpTriggerAttribute>()) != null)
                                   .ToList();
+
+            if (!tags.Any())
+            {
+                return methods;
+            }
+
+            methods = methods.Where(p => p.GetCustomAttribute<OpenApiOperationAttribute>()
+                                          .Tags
+                                          .Any(q => tags.Contains(q)))
+                             .ToList();
 
             return methods;
         }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/HttpRequestObject.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/HttpRequestObject.cs
@@ -1,6 +1,8 @@
+using System.IO;
 using System.Linq;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Extensions;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
@@ -24,6 +26,9 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi
             this.Host = new[] { 80, 443 }.Contains(req.Url.Port)
                         ? new HostString(req.Url.Authority)
                         : new HostString(req.Url.Host, req.Url.Port);
+
+            this.Query = req.Queries();
+            this.Body = req.Body;
         }
 
         /// <inheritdoc/>
@@ -31,5 +36,11 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi
 
         /// <inheritdoc/>
         public virtual HostString Host { get; }
+
+        /// <inheritdoc/>
+        public virtual IQueryCollection Query { get;}
+
+        /// <inheritdoc/>
+        public virtual Stream Body { get;}
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IDocument.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IDocument.cs
@@ -1,7 +1,6 @@
 using System.Reflection;
 using System.Threading.Tasks;
 
-using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors;
 using Microsoft.OpenApi;

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IHttpRequestDataObject.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IHttpRequestDataObject.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions
@@ -16,5 +18,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions
         /// Gets the host header that may include the port number.
         /// </summary>
         HostString Host { get; }
+
+        /// <summary>
+        /// Gets the query collection.
+        /// </summary>
+        IQueryCollection Query { get;}
+
+        /// <summary>
+        /// Gets the request payload stream.
+        /// </summary>
+        Stream Body { get;}
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/DocumentHelperExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/DocumentHelperExtensions.cs
@@ -24,8 +24,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
         /// </summary>
         /// <param name="helper"><see cref="IDocumentHelper"/> instance.</param>
         /// <param name="assembly">Assembly of Azure Function instance.</param>
+        /// <param name="tags">List of tags to filter methods.</param>
         /// <returns>List of <see cref="MethodInfo"/> instances representing HTTP triggers.</returns>
-        public static List<MethodInfo> GetHttpTriggerMethods(this IDocumentHelper helper, Assembly assembly)
+        public static List<MethodInfo> GetHttpTriggerMethods(this IDocumentHelper helper, Assembly assembly, IEnumerable<string> tags = null)
         {
             var methods = assembly.GetLoadableTypes()
                                   .SelectMany(p => p.GetMethods())
@@ -34,6 +35,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
                                   .Where(p => !p.ExistsCustomAttribute<OpenApiIgnoreAttribute>())
                                   .Where(p => p.GetParameters().FirstOrDefault(q => q.ExistsCustomAttribute<HttpTriggerAttribute>()) != null)
                                   .ToList();
+
+            if (!tags.Any())
+            {
+                return methods;
+            }
+
+            methods = methods.Where(p => p.GetCustomAttribute<OpenApiOperationAttribute>()
+                                          .Tags.Any(q => tags.Contains(q)))
+                             .ToList();
 
             return methods;
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/StringExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/StringExtensions.cs
@@ -1,5 +1,7 @@
 using System;
 
+using Microsoft.Extensions.Primitives;
+
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
 {
     /// <summary>
@@ -31,6 +33,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
             }
 
             return value;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="StringValues"/> value to array of string.
+        /// </summary>
+        /// <param name="value"><see cref="StringValues"/> value.</param>
+        /// <param name="delimiter">Delimiter to split values.</param>
+        /// <returns>Returns the array of string.</returns>
+        public static string[] ToArray(this StringValues value, string delimiter = ",")
+        {
+            if (value.IsNullOrDefault())
+            {
+                return new string[0];
+            }
+
+            var values = value.ToString();
+            if (values.IsNullOrWhiteSpace())
+            {
+                return new string[0];
+            }
+
+            return values.Split(new[] { delimiter }, StringSplitOptions.RemoveEmptyEntries);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/Document.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/Document.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
 
         private NamingStrategy _strategy;
         private VisitorCollection _collection;
+        private IHttpRequestDataObject _req;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Document"/> class.
@@ -65,8 +66,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
         /// <inheritdoc />
         public IDocument AddServer(IHttpRequestDataObject req, string routePrefix, IOpenApiConfigurationOptions options = null)
         {
+            this._req = req;
+
             var prefix = string.IsNullOrWhiteSpace(routePrefix) ? string.Empty : $"/{routePrefix}";
-            var baseUrl = $"{req.Scheme}://{req.Host}{prefix}";
+            var baseUrl = $"{this._req.Scheme}://{this._req.Host}{prefix}";
 
             var server = new OpenApiServer { Url = baseUrl };
 
@@ -131,7 +134,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
 
             var paths = new OpenApiPaths();
 
-            var methods = this._helper.GetHttpTriggerMethods(assembly);
+            var tags = this._req.Query["tag"].ToArray(",");
+            var methods = this._helper.GetHttpTriggerMethods(assembly, tags);
             foreach (var method in methods)
             {
                 var trigger = this._helper.GetHttpTriggerAttribute(method);

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/HttpRequestObject.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/HttpRequestObject.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
@@ -19,6 +21,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
 
             this.Scheme = req.Scheme;
             this.Host = req.Host;
+            this.Query = req.Query;
+            this.Body = req.Body;
         }
 
         /// <inheritdoc/>
@@ -26,5 +30,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
 
         /// <inheritdoc/>
         public virtual HostString Host { get; }
+
+        /// <inheritdoc/>
+        public virtual IQueryCollection Query { get;}
+
+        /// <inheritdoc/>
+        public virtual Stream Body { get;}
     }
 }

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/Extensions/HttpRequestDataExtensionsTests.cs
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/Extensions/HttpRequestDataExtensionsTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
             var baseHost = "localhost";
             var uri = Uri.TryCreate($"http://{baseHost}", UriKind.Absolute, out var tried) ? tried : null;
 
-            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri);
+            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri, body: null);
 
             var result = OpenApiHttpRequestDataExtensions.Queries(req);
 
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
             var baseHost = "localhost";
             var uri = Uri.TryCreate($"http://{baseHost}?{querystring}", UriKind.Absolute, out var tried) ? tried : null;
 
-            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri);
+            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri, body: null);
 
             var result = OpenApiHttpRequestDataExtensions.Queries(req);
 
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
             var baseHost = "localhost";
             var uri = Uri.TryCreate($"http://{baseHost}?{querystring}", UriKind.Absolute, out var tried) ? tried : null;
 
-            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri);
+            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri, body: null);
 
             var result = OpenApiHttpRequestDataExtensions.Queries(req);
 
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
             var baseHost = "localhost";
             var uri = Uri.TryCreate($"http://{baseHost}?{querystring}", UriKind.Absolute, out var tried) ? tried : null;
 
-            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri);
+            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri, body: null);
 
             var result = (string) OpenApiHttpRequestDataExtensions.Query(req, key);
 
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
             var baseHost = "localhost";
             var uri = Uri.TryCreate($"http://{baseHost}", UriKind.Absolute, out var tried) ? tried : null;
 
-            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri);
+            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri, body: null);
 
             var result = (string) OpenApiHttpRequestDataExtensions.Query(req, "hello");
 
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
             var baseHost = "localhost";
             var uri = Uri.TryCreate($"http://{baseHost}?{querystring}", UriKind.Absolute, out var tried) ? tried : null;
 
-            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri);
+            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri, body: null);
 
             var result = (string) OpenApiHttpRequestDataExtensions.Query(req, "hello");
 

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/Fakes/FakeHttpRequestData.cs
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/Fakes/FakeHttpRequestData.cs
@@ -9,12 +9,13 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Fakes
 {
     public class FakeHttpRequestData : HttpRequestData
     {
-        public FakeHttpRequestData(FunctionContext functionContext, Uri uri) : base(functionContext)
+        public FakeHttpRequestData(FunctionContext functionContext, Uri uri, Stream body) : base(functionContext)
         {
             this.Url = uri;
+            this.Body = body;
         }
 
-        public override Stream Body => throw new NotImplementedException();
+        public override Stream Body { get; }
 
         public override HttpHeadersCollection Headers => throw new NotImplementedException();
 

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/HttpRequestObjectTests.cs
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/HttpRequestObjectTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.IO;
 using System.Linq;
+using System.Text;
 
 using FluentAssertions;
 
@@ -23,24 +25,31 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         }
 
         [DataTestMethod]
-        [DataRow("http", "localhost", 80)]
-        [DataRow("http", "localhost", 7071)]
-        [DataRow("https", "localhost", 443)]
-        [DataRow("https", "localhost", 47071)]
-        public void Given_Parameter_When_Instantiated_Then_It_Should_Return_Result(string scheme, string hostname, int port)
+        [DataRow("http", "localhost", 80, "hello", "world", "lorem ipsum")]
+        [DataRow("http", "localhost", 7071, "lorem", "ipsum", "hello world")]
+        [DataRow("https", "localhost", 443, "hello", "world", "lorem ipsum")]
+        [DataRow("https", "localhost", 47071, "lorem", "ipsum", "hello world")]
+        public void Given_Parameter_When_Instantiated_Then_It_Should_Return_Result(string scheme, string hostname, int port, string key, string value, string payload)
         {
             var context = new Mock<FunctionContext>();
 
             var ports = new[] { 80, 443 };
             var baseHost = $"{hostname}{(ports.Contains(port) ? string.Empty : $":{port}")}";
-            var uri = Uri.TryCreate($"{scheme}://{baseHost}", UriKind.Absolute, out var tried) ? tried : null;
+            var uri = Uri.TryCreate($"{scheme}://{baseHost}?{key}={value}", UriKind.Absolute, out var tried) ? tried : null;
+            var bytes = Encoding.UTF8.GetBytes(payload);
+            var body = new MemoryStream(bytes);
 
-            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri);
+            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri, body);
 
             var result = new HttpRequestObject(req);
 
             result.Scheme.Should().Be(scheme);
             result.Host.Value.Should().Be(baseHost);
+            result.Query.Should().ContainKey(key);
+            ((string) result.Query[key]).Should().Be(value);
+            (new StreamReader(result.Body)).ReadToEnd().Should().Be(payload);
+
+            body.Dispose();
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/AssemblyExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/AssemblyExtensionsTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Reflection;
 using System.Reflection.Emit;
+
 using FluentAssertions;
+
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/StringExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/StringExtensionsTests.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+using Microsoft.Extensions.Primitives;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
+{
+    [TestClass]
+    public class StringExtensionsTests
+    {
+        [TestMethod]
+        public void Given_Null_StringValues_When_ToArray_Invoked_Then_It_Should_Return_Result()
+        {
+            var sv = default(StringValues);
+
+            var result = StringExtensions.ToArray(sv, ",");
+
+            result.Should().BeEquivalentTo(new string[0]);
+        }
+
+        [DataTestMethod]
+        [DataRow("hello world")]
+        [DataRow("hello", "world")]
+        public void Given_StringValues_When_ToArray_Invoked_Then_It_Should_Return_Result(params string[] values)
+        {
+            var sv = new StringValues(values);
+
+            var result = StringExtensions.ToArray(sv, ",");
+
+            result.Should().BeEquivalentTo(values);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.csproj
@@ -19,6 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.6" />


### PR DESCRIPTION
This PR is to solve the issue identified at #177.

After this PR is merged, you can filter which endpoints are exposed, based on their tags. Here are the examples:

* **Swagger UI**
  * To expose all endpoints:
    * `http://localhost:7071/api/swagger/ui`
  * To expose endpoints tagged by `pet`:
    * `http://localhost:7071/api/swagger/ui?tag=pet`
  * To expose endpoints tagged by either `pet` or `store`:
    * `http://localhost:7071/api/swagger/ui?tag=pet&tag=store` 
    * `http://localhost:7071/api/swagger/ui?tag=pet,store` 
* **OpenAPI document**
  * To expose all endpoints:
    * `http://localhost:7071/api/swagger.json`
    * `http://localhost:7071/api/openapi/v2.json`
    * `http://localhost:7071/api/openapi/v3.json`
  * To expose endpoints tagged by `pet`:
    * `http://localhost:7071/api/swagger.json?tag=pet`
    * `http://localhost:7071/api/openapi/v2.json?tag=pet`
    * `http://localhost:7071/api/openapi/v3.json?tag=pet`
  * To expose endpoints tagged by either `pet` or `store`:
    * `http://localhost:7071/api/swagger.json?tag=pet&tag=store` 
    * `http://localhost:7071/api/swagger.json?tag=pet,store` 
    * `http://localhost:7071/api/openapi/v2.json?tag=pet&tag=store`
    * `http://localhost:7071/api/openapi/v2.json?tag=pet,store`
    * `http://localhost:7071/api/openapi/v3.json?tag=pet&tag=store`
    * `http://localhost:7071/api/openapi/v3.json?tag=pet,store`
