### PR TITLE
Addressing the issue of System.ArgumentException: An item with the same key has already been added

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Attributes/OpenApiPayloadAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Attributes/OpenApiPayloadAttribute.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes
         /// <remarks>
         /// This property is taken into account if UseTypeFullName set to true.
         /// </remarks>
-        public string TypeFullNameAlias
+        public string BodyTypeAlias
         {
             get => this._typeFullNameAlias;
             set

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Attributes/OpenApiPayloadAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Attributes/OpenApiPayloadAttribute.cs
@@ -39,5 +39,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes
         /// Gets or sets the type of the example. It SHOULD be inheriting the <see cref="OpenApiExample{T}"/> class.
         /// </summary>
         public virtual Type Example { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating whether or not the response's type's name should be used. 
+        /// </summary>
+        /// <remarks>
+        /// The default value is false.
+        /// </remarks>
+        public bool UseTypeFullName { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Attributes/OpenApiPayloadAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Attributes/OpenApiPayloadAttribute.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes
     /// </summary>
     public abstract class OpenApiPayloadAttribute : Attribute
     {
+        private string _typeFullNameAlias = string.Empty;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="OpenApiPayloadAttribute"/> class.
         /// </summary>
@@ -47,5 +49,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes
         /// The default value is false.
         /// </remarks>
         public bool UseTypeFullName { get; set; }
+
+        /// <summary>
+        /// Gets or optionally sets the type full name's alias. 
+        /// </summary>
+        /// <remarks>
+        /// This property is taken into account if UseTypeFullName set to true.
+        /// </remarks>
+        public string TypeFullNameAlias
+        {
+            get => this._typeFullNameAlias;
+            set
+            {
+                if(value.Contains(".") || value.Contains("+"))
+                {
+                    throw new ArgumentException($"The alias name should not contain dot (.) or plus (+).");
+                }
+                this._typeFullNameAlias = value;
+            }
+        }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Attributes/OpenApiResponseWithBodyAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Attributes/OpenApiResponseWithBodyAttribute.cs
@@ -41,5 +41,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes
         /// Gets or sets the value indicating whether the response payload is deprecated or not.
         /// </summary>
         public virtual bool Deprecated { get; set; }
+
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
             string GetTypeFullNameAlias(Type type, List<OpenApiResponseWithBodyAttribute> openApiResponseWithBodyAttributes)
             {
                 var attribute = openApiResponseWithBodyAttributes.Where(p => p.BodyType.FullName == type.FullName);
-                var typeFullNameAlias = attribute.FirstOrDefault()?.TypeFullNameAlias;
+                var typeFullNameAlias = attribute.FirstOrDefault()?.BodyTypeAlias;
                 return typeFullNameAlias;
             }
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
 
             var rootSchemas = new Dictionary<string, OpenApiSchema>();
             var schemas = new Dictionary<string, OpenApiSchema>();
-            this._acceptor.Types = types.ToDictionary(p => p.GetOpenApiReferenceId(p.IsOpenApiDictionary(), p.IsOpenApiArray(), namingStrategy, UtilizeTypeFullName(p, responsesAttributes)), p => p);
+            this._acceptor.Types = types.ToDictionary(p => p.GetOpenApiReferenceId(p.IsOpenApiDictionary(), p.IsOpenApiArray(), namingStrategy, GetTypeFullNameAlias(p, responsesAttributes) ,UtilizeTypeFullName(p, responsesAttributes)), p => p);
             this._acceptor.RootSchemas = rootSchemas;
             this._acceptor.Schemas = schemas;
 
@@ -171,12 +171,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
             {
                 var attribute = openApiResponseWithBodyAttributes.Where(p => p.BodyType.FullName == type.FullName);
                 var typeFullNameUtilized = attribute.FirstOrDefault()?.UseTypeFullName ?? false;
+                var typeFullNameAlias = GetTypeFullNameAlias(type, openApiResponseWithBodyAttributes);
 
-                if (typeFullNameUtilized && !this._acceptor.TypesAcceptedWithFullName.Contains(type.FullName))
+                if (typeFullNameUtilized && !this._acceptor.TypesAcceptedWithFullName.TryGetValue(type.FullName, out var _))
                 {
-                    this._acceptor.TypesAcceptedWithFullName.Add(type.FullName);
+                    this._acceptor.TypesAcceptedWithFullName.Add(type.FullName, typeFullNameAlias);
                 }
                 return typeFullNameUtilized;
+            }
+            string GetTypeFullNameAlias(Type type, List<OpenApiResponseWithBodyAttribute> openApiResponseWithBodyAttributes)
+            {
+                var attribute = openApiResponseWithBodyAttributes.Where(p => p.BodyType.FullName == type.FullName);
+                var typeFullNameAlias = attribute.FirstOrDefault()?.TypeFullNameAlias;
+                return typeFullNameAlias;
             }
         }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiPayloadAttributeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiPayloadAttributeExtensions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
                 var reference = new OpenApiReference()
                 {
                     Type = ReferenceType.Schema,
-                    Id = attribute.BodyType.GetOpenApiReferenceId(isDictionary: false, isList: false, namingStrategy)
+                    Id = attribute.BodyType.GetOpenApiReferenceId(isDictionary: false, isList: false, namingStrategy, attribute.UseTypeFullName)
                 };
 
                 schema.Reference = reference;

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiPayloadAttributeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiPayloadAttributeExtensions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
                 var reference = new OpenApiReference()
                 {
                     Type = ReferenceType.Schema,
-                    Id = attribute.BodyType.GetOpenApiReferenceId(isDictionary: false, isList: false, namingStrategy, attribute.TypeFullNameAlias, attribute.UseTypeFullName)
+                    Id = attribute.BodyType.GetOpenApiReferenceId(isDictionary: false, isList: false, namingStrategy, attribute.BodyTypeAlias, attribute.UseTypeFullName)
                 };
 
                 schema.Reference = reference;

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiPayloadAttributeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiPayloadAttributeExtensions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
                 var reference = new OpenApiReference()
                 {
                     Type = ReferenceType.Schema,
-                    Id = attribute.BodyType.GetOpenApiReferenceId(isDictionary: false, isList: false, namingStrategy, attribute.UseTypeFullName)
+                    Id = attribute.BodyType.GetOpenApiReferenceId(isDictionary: false, isList: false, namingStrategy, attribute.TypeFullNameAlias, attribute.UseTypeFullName)
                 };
 
                 schema.Reference = reference;

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
@@ -366,9 +366,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
         /// <param name="isDictionary">Value indicating whether the type is <see cref="Dictionary{TKey, TValue}"/> or not.</param>
         /// <param name="isList">Value indicating whether the type is <see cref="List{T}"/> or not.</param>
         /// <param name="namingStrategy"><see cref="NamingStrategy"/> instance.</param>
+        /// <param name="useTypeFullName">Value indicating whether to utilize the type's full name</param>
         /// <returns>Returns the OpenAPI reference ID.</returns>
-        public static string GetOpenApiReferenceId(this Type type, bool isDictionary, bool isList, NamingStrategy namingStrategy = null)
+        public static string GetOpenApiReferenceId(this Type type, bool isDictionary, bool isList, NamingStrategy namingStrategy = null, bool useTypeFullName = false)
         {
+            var typeName = useTypeFullName ? type.FullName : type.Name;
+
             if (namingStrategy.IsNullOrDefault())
             {
                 namingStrategy = new DefaultNamingStrategy();
@@ -376,18 +379,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
 
             if (isDictionary || isList)
             {
-                var name = type.Name.Split('`').First() + "_" + type.GetOpenApiSubTypeName(namingStrategy);
+                var name = typeName.Split('`').First() + "_" + type.GetOpenApiSubTypeName(namingStrategy);
 
                 return namingStrategy.GetPropertyName(name, hasSpecifiedName: false);
             }
 
             if (type.IsGenericType)
             {
-                return namingStrategy.GetPropertyName(type.Name.Split('`').First(), false) + "_" +
+                return namingStrategy.GetPropertyName(typeName.Split('`').First(), false) + "_" +
                        string.Join("_", type.GenericTypeArguments.Select(a => namingStrategy.GetPropertyName(a.Name, false)));
             }
 
-            return namingStrategy.GetPropertyName(type.Name, hasSpecifiedName: false);
+            return namingStrategy.GetPropertyName(typeName, hasSpecifiedName: false);
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
@@ -368,9 +368,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
         /// <param name="namingStrategy"><see cref="NamingStrategy"/> instance.</param>
         /// <param name="useTypeFullName">Value indicating whether to utilize the type's full name</param>
         /// <returns>Returns the OpenAPI reference ID.</returns>
-        public static string GetOpenApiReferenceId(this Type type, bool isDictionary, bool isList, NamingStrategy namingStrategy = null, bool useTypeFullName = false)
+        public static string GetOpenApiReferenceId(
+            this Type type,
+            bool isDictionary,
+            bool isList,
+            NamingStrategy namingStrategy = null,
+            bool useTypeFullName = false)
         {
+            const string Delimiter = "_";
             var typeName = useTypeFullName ? type.FullName : type.Name;
+            var propertyName = string.Empty;
 
             if (namingStrategy.IsNullOrDefault())
             {
@@ -379,18 +386,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
 
             if (isDictionary || isList)
             {
-                var name = typeName.Split('`').First() + "_" + type.GetOpenApiSubTypeName(namingStrategy);
+                var name = typeName.Split('`').First() + Delimiter + type.GetOpenApiSubTypeName(namingStrategy);
 
-                return namingStrategy.GetPropertyName(name, hasSpecifiedName: false);
+                propertyName = namingStrategy.GetPropertyName(name, hasSpecifiedName: false);
             }
 
             if (type.IsGenericType)
             {
-                return namingStrategy.GetPropertyName(typeName.Split('`').First(), false) + "_" +
-                       string.Join("_", type.GenericTypeArguments.Select(a => namingStrategy.GetPropertyName(a.Name, false)));
+                propertyName = namingStrategy.GetPropertyName(typeName.Split('`').First(), false) + Delimiter +
+                       string.Join(Delimiter, type.GenericTypeArguments.Select(a => namingStrategy.GetPropertyName(a.Name, false)));
             }
 
-            return namingStrategy.GetPropertyName(typeName, hasSpecifiedName: false);
+            propertyName = namingStrategy.GetPropertyName(typeName, hasSpecifiedName: false);
+            return ConformPropertyName();
+            string ConformPropertyName() => propertyName.Replace(".", Delimiter).Replace("+", Delimiter);
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
@@ -370,7 +370,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
         /// <param name="useTypeFullName">Value indicating whether to utilize the type's full name</param>
         /// <returns>Returns the OpenAPI reference ID.</returns>
         /// <remarks>
-        /// If useTypeFullName is true and typeFullNameAlias not specified, the reference Id will be constructed as {FirstPartOfNamespace}_{NestedTypeName}.
+        /// If useTypeFullName is true and typeFullNameAlias specified, the reference Id will equal to the full type's alias name.
         /// </remarks>
         public static string GetOpenApiReferenceId(
             this Type type,
@@ -403,27 +403,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
             }
 
             propertyName = namingStrategy.GetPropertyName(typeName, hasSpecifiedName: false);
-            return ConformReference(ShortenReference(propertyName));
-            string ConformReference(string referenceId) => referenceId.Replace(".", Delimiter).Replace("+", Delimiter);
-            string ShortenReference(string referenceId)
-            {
-                if (useTypeFullName)
-                {
-                    if (string.IsNullOrEmpty(typeFullNameAlias))
-                    {
-                        var tokens = referenceId.Split(Delimiter.ToCharArray()[0]);
-                        if (tokens?.Length > 1)
-                        {
-                            return $"{tokens[0]}_{tokens[tokens.Length - 1]}";
-                        }
-                    }
-                    else
-                    {
-                        return typeFullNameAlias;
-                    }
-                }
-                return referenceId;
-            }
+            return UseTypeFullNameAlias(ConformReferenceId());
+            string ConformReferenceId() => propertyName.Replace(".", Delimiter).Replace("+", Delimiter);
+            string UseTypeFullNameAlias(string referenceId)
+                => useTypeFullName && !string.IsNullOrEmpty(typeFullNameAlias)
+                    ? typeFullNameAlias
+                    : referenceId;
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
@@ -393,12 +393,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
             {
                 var name = typeName.Split('`').First() + Delimiter + type.GetOpenApiSubTypeName(namingStrategy);
 
-                propertyName = namingStrategy.GetPropertyName(name, hasSpecifiedName: false);
+                return namingStrategy.GetPropertyName(name, hasSpecifiedName: false);
             }
 
             if (type.IsGenericType)
             {
-                propertyName = namingStrategy.GetPropertyName(typeName.Split('`').First(), false) + Delimiter +
+                return namingStrategy.GetPropertyName(typeName.Split('`').First(), false) + Delimiter +
                        string.Join(Delimiter, type.GenericTypeArguments.Select(a => namingStrategy.GetPropertyName(a.Name, false)));
             }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
@@ -366,18 +366,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
         /// <param name="isDictionary">Value indicating whether the type is <see cref="Dictionary{TKey, TValue}"/> or not.</param>
         /// <param name="isList">Value indicating whether the type is <see cref="List{T}"/> or not.</param>
         /// <param name="namingStrategy"><see cref="NamingStrategy"/> instance.</param>
-        /// <param name="typeFullNameAlias">Value indicating the optional alias name given to a type's full name to shorten the references</param>
+        /// <param name="bodyTypeAlias">Value indicating the optional alias name given to a type's full name to shorten the references</param>
         /// <param name="useTypeFullName">Value indicating whether to utilize the type's full name</param>
         /// <returns>Returns the OpenAPI reference ID.</returns>
         /// <remarks>
-        /// If useTypeFullName is true and typeFullNameAlias specified, the reference Id will equal to the full type's alias name.
+        /// If useTypeFullName is true and bodyTypeAlias specified, the reference Id will equal to the full type's alias name.
         /// </remarks>
         public static string GetOpenApiReferenceId(
             this Type type,
             bool isDictionary,
             bool isList,
             NamingStrategy namingStrategy = null,
-            string typeFullNameAlias = null,
+            string bodyTypeAlias = null,
             bool useTypeFullName = false)
         {
             const string Delimiter = "_";
@@ -403,11 +403,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
             }
 
             propertyName = namingStrategy.GetPropertyName(typeName, hasSpecifiedName: false);
-            return UseTypeFullNameAlias(ConformReferenceId());
+            return UseBodyTypeAlias(ConformReferenceId());
             string ConformReferenceId() => propertyName.Replace(".", Delimiter).Replace("+", Delimiter);
-            string UseTypeFullNameAlias(string referenceId)
-                => useTypeFullName && !string.IsNullOrEmpty(typeFullNameAlias)
-                    ? typeFullNameAlias
+            string UseBodyTypeAlias(string referenceId)
+                => useTypeFullName && !string.IsNullOrEmpty(bodyTypeAlias)
+                    ? bodyTypeAlias
                     : referenceId;
         }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/IOpenApiSchemaAcceptor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/IOpenApiSchemaAcceptor.cs
@@ -28,8 +28,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
         Dictionary<string, Type> Types { get; set; }
 
         /// <summary>
-        /// Gets and sets the list of types processed with their full name if exist.
+        /// Gets and sets the dictionary of types processed with their full name if exist.
         /// </summary>
-        List<string> TypesAcceptedWithFullName { get; set; }
+        /// <remarks>
+        /// The key is the type's full name and the value is the type's full name's alias if exists.
+        /// </remarks>
+        Dictionary<string, string> TypesAcceptedWithFullName { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/IOpenApiSchemaAcceptor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/IOpenApiSchemaAcceptor.cs
@@ -26,5 +26,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
         /// Gets the list of <see cref="Type"/> objects.
         /// </summary>
         Dictionary<string, Type> Types { get; set; }
+
+        /// <summary>
+        /// Gets and sets the list of types processed with their full name if exist.
+        /// </summary>
+        List<string> TypesAcceptedWithFullName { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
@@ -112,12 +112,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
                                  .ToDictionary(p => p.GetJsonPropertyName(namingStrategy), p => p);
 
             this.ProcessProperties(instance, name, properties, namingStrategy);
-
+            var typeFullNameAlias = string.Empty;
+            var useTypeFullName = (acceptor as IOpenApiSchemaAcceptor)?.TypesAcceptedWithFullName?.TryGetValue(type.Value.FullName, out typeFullNameAlias);
             // Adds the reference.
             var reference = new OpenApiReference()
             {
                 Type = ReferenceType.Schema,
-                Id = type.Value.GetOpenApiReferenceId(isDictionary: false, isList: false, namingStrategy, (acceptor as IOpenApiSchemaAcceptor)?.TypesAcceptedWithFullName?.Contains(type.Value.FullName) ?? false)
+                Id = type.Value.GetOpenApiReferenceId(isDictionary: false, isList: false, namingStrategy, typeFullNameAlias, useTypeFullName ?? false)
             };
 
             instance.Schemas[name].Reference = reference;

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
             var reference = new OpenApiReference()
             {
                 Type = ReferenceType.Schema,
-                Id = type.Value.GetOpenApiReferenceId(isDictionary: false, isList: false, namingStrategy)
+                Id = type.Value.GetOpenApiReferenceId(isDictionary: false, isList: false, namingStrategy, (acceptor as IOpenApiSchemaAcceptor)?.TypesAcceptedWithFullName?.Contains(type.Value.FullName) ?? false)
             };
 
             instance.Schemas[name].Reference = reference;

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/OpenApiSchemaAcceptor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/OpenApiSchemaAcceptor.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
         public Dictionary<string, PropertyInfo> Properties { get; set; } = new Dictionary<string, PropertyInfo>();
 
         /// <inheritdoc />
-        public List<string> TypesAcceptedWithFullName { get; set; } = new List<string>();
+        public Dictionary<string,string> TypesAcceptedWithFullName { get; set; } = new Dictionary<string, string>();
 
         /// <inheritdoc />
         public void Accept(VisitorCollection collection, NamingStrategy namingStrategy)

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/OpenApiSchemaAcceptor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/OpenApiSchemaAcceptor.cs
@@ -50,6 +50,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
         public Dictionary<string, PropertyInfo> Properties { get; set; } = new Dictionary<string, PropertyInfo>();
 
         /// <inheritdoc />
+        public List<string> TypesAcceptedWithFullName { get; set; } = new List<string>();
+
+        /// <inheritdoc />
         public void Accept(VisitorCollection collection, NamingStrategy namingStrategy)
         {
             // Checks the properties only.


### PR DESCRIPTION
This PR is related to issue #94 

The fix consists of the following key enhancements:

- Added `UseTypeFullName` boolean property to `OpenApiPayloadAttribute` class and defaulted it to `false`
- Introduced the local function of `UtilizeTypeFullName` in `GetOpenApiResponses()` method to determine whether to use `Type.Name` or `Type.FullName`

```cs
bool UtilizeTypeFullName(Type type, List<OpenApiResponseWithBodyAttribute> openApiResponseWithBodyAttributes)
{
    var attribute = openApiResponseWithBodyAttributes.Where(p => p.BodyType.FullName == type.FullName);
    var typeFullNameUtilized = attribute.FirstOrDefault()?.UseTypeFullName ?? false;

     if (typeFullNameUtilized && !this._acceptor.TypesAcceptedWithFullName.Contains(type.FullName))
     {
           this._acceptor.TypesAcceptedWithFullName.Add(type.FullName);
     }
     return typeFullNameUtilized;
}
```
- Added `List<string> TypesAcceptedWithFullName { get; set; }` property to the accelerator to track eligible types' full names
- `GetOpenApiReferenceId(...)` method augmented to receive the boolean parameter of `UseTypeFullName`
- Replaced `Id = type.Value.GetOpenApiReferenceId(isDictionary: false, isList: false, namingStrategy)` with `Id = type.Value.GetOpenApiReferenceId(isDictionary: false, isList: false, namingStrategy, (acceptor as IOpenApiSchemaAcceptor)?.TypesAcceptedWithFullName?.Contains(type.Value.FullName) ?? false)` in the `Visit` method of `ObjectTypeVisitor` class