### PR TITLE
Support "Base Object (root of all classes)" type

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/BaseObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/BaseObjectTypeVisitor.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+using Microsoft.OpenApi.Models;
+
+using Newtonsoft.Json.Serialization;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
+{
+    /// <summary>
+    /// This represents the type visitor for <see cref="DateTime"/>.
+    /// </summary>
+    public class BaseObjectTypeVisitor : TypeVisitor
+    {
+        /// <inheritdoc />
+        public BaseObjectTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
+        public override bool IsVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type, TypeCode.Object) && type == typeof(object);
+
+            return isVisitable;
+        }
+
+        /// <inheritdoc />
+        public override void Visit(IAcceptor acceptor, KeyValuePair<string, Type> type, NamingStrategy namingStrategy, params Attribute[] attributes)
+        {
+            var title = type.Value.IsGenericType
+                ? namingStrategy.GetPropertyName(type.Value.Name.Split('`').First(), hasSpecifiedName: false) + "_" +
+                  string.Join("_",
+                      type.Value.GenericTypeArguments.Select(a => namingStrategy.GetPropertyName(a.Name, false)))
+                : namingStrategy.GetPropertyName(type.Value.Name, hasSpecifiedName: false);
+            this.Visit(acceptor, name: type.Key, title: title, dataType: "object", dataFormat: null, attributes: attributes);
+        }
+
+        /// <inheritdoc />
+        public override bool IsParameterVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type);
+
+            return isVisitable;
+        }
+
+        /// <inheritdoc />
+        public override OpenApiSchema ParameterVisit(Type type, NamingStrategy namingStrategy)
+        {
+            return this.ParameterVisit(dataType: "object", dataFormat: null);
+        }
+
+        /// <inheritdoc />
+        public override bool IsPayloadVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type);
+
+            return isVisitable;
+        }
+
+        /// <inheritdoc />
+        public override OpenApiSchema PayloadVisit(Type type, NamingStrategy namingStrategy)
+        {
+            return this.PayloadVisit(dataType: "object", dataFormat: null);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/BaseObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/BaseObjectTypeVisitor.cs
@@ -40,20 +40,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
         }
 
         /// <inheritdoc />
-        public override bool IsParameterVisitable(Type type)
-        {
-            var isVisitable = this.IsVisitable(type);
-
-            return isVisitable;
-        }
-
-        /// <inheritdoc />
-        public override OpenApiSchema ParameterVisit(Type type, NamingStrategy namingStrategy)
-        {
-            return this.ParameterVisit(dataType: "object", dataFormat: null);
-        }
-
-        /// <inheritdoc />
         public override bool IsPayloadVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type);

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
 
         private readonly HashSet<string> _noAddedKeys = new HashSet<string>
         {
-            "object", "jToken", "jObject"
+            "OBJECT", "JTOKEN", "JOBJECT"
         };
 
         /// <inheritdoc />
@@ -204,7 +204,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
                                               .Select(p => p.First())
                                               .ToDictionary(p => p.Value.Title, p => p.Value);
 
-            foreach (var schema in schemasToBeAdded.Where(p => !this._noAddedKeys.Contains(p.Key)))
+            foreach (var schema in schemasToBeAdded.Where(p => !this._noAddedKeys.Contains(p.Key.ToUpperInvariant())))
             {
                 if (instance.RootSchemas.ContainsKey(schema.Key))
                 {

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
@@ -19,6 +19,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
     /// </summary>
     public class ObjectTypeVisitor : TypeVisitor
     {
+        private readonly HashSet<Type> _noVisitableTypes = new HashSet<Type>
+        {
+            typeof(Guid),       typeof(DateTime),       typeof(DateTimeOffset),
+            typeof(Uri),        typeof(Type),           typeof(object),
+            typeof(byte[])
+        };
+
+        private readonly HashSet<string> _noAddedKeys = new HashSet<string>
+        {
+            "object", "jToken", "jObject"
+        };
+
         /// <inheritdoc />
         public ObjectTypeVisitor(VisitorCollection visitorCollection)
             : base(visitorCollection)
@@ -30,27 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Object);
 
-            if (type == typeof(Guid))
-            {
-                isVisitable = false;
-            }
-            else if (type == typeof(DateTime))
-            {
-                isVisitable = false;
-            }
-            else if (type == typeof(DateTimeOffset))
-            {
-                isVisitable = false;
-            }
-            else if (type == typeof(Uri))
-            {
-                isVisitable = false;
-            }
-            else if (type == typeof(Type))
-            {
-                isVisitable = false;
-            }
-            else if(type == typeof(byte[]))
+            if (this._noVisitableTypes.Contains(type))
             {
                 isVisitable = false;
             }
@@ -212,7 +204,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
                                               .Select(p => p.First())
                                               .ToDictionary(p => p.Value.Title, p => p.Value);
 
-            foreach (var schema in schemasToBeAdded.Where(p => p.Key != "jObject" && p.Key != "jToken"))
+            foreach (var schema in schemasToBeAdded.Where(p => !this._noAddedKeys.Contains(p.Key)))
             {
                 if (instance.RootSchemas.ContainsKey(schema.Key))
                 {

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_ApplicationJson_BaseObject_Tests.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_ApplicationJson_BaseObject_Tests.cs
@@ -1,0 +1,76 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
+{
+    [TestClass]
+    [TestCategory(Constants.TestCategory)]
+    public class Get_ApplicationJson_BaseObject_Tests
+    {
+        private static HttpClient http = new HttpClient();
+
+        private JObject _doc;
+
+        [TestInitialize]
+        public async Task Init()
+        {
+            var json = await http.GetStringAsync(Constants.OpenApiDocEndpoint).ConfigureAwait(false);
+            this._doc = JsonConvert.DeserializeObject<JObject>(json);
+        }
+
+        [DataTestMethod]
+        [DataRow("/get-applicationjson-base-object", "get", "200")]
+        public void Given_OpenApiDocument_Then_It_Should_Return_OperationResponse(string path, string operationType, string responseCode)
+        {
+            var responses = this._doc["paths"][path][operationType]["responses"];
+
+            responses[responseCode].Should().NotBeNull();
+        }
+
+        [DataTestMethod]
+        [DataRow("/get-applicationjson-base-object", "get", "200", "application/json")]
+        public void Given_OpenApiDocument_Then_It_Should_Return_OperationResponseContentType(string path, string operationType, string responseCode, string contentType)
+        {
+            var content = this._doc["paths"][path][operationType]["responses"][responseCode]["content"];
+
+            content[contentType].Should().NotBeNull();
+        }
+
+        [DataTestMethod]
+        [DataRow("/get-applicationjson-base-object", "get", "200", "application/json", "stringObjectModel")]
+        public void Given_OpenApiDocument_Then_It_Should_Not_Return_ReferenceSchema(string path, string operationType, string responseCode, string contentType, string reference)
+        {
+            var content = this._doc["paths"][path][operationType]["responses"][responseCode]["content"];
+        }
+
+
+        [DataTestMethod]
+        [DataRow("hasBaseObjectModel", "objectValue", true)]
+        [DataRow("hasBaseObjectModel", "nonObjectValue", false)]
+        [DataRow("hasBaseObjectModel", "subModel", false)]
+        [DataRow("hasBaseObjectSubModel", "subObjectValue",true)]
+        public void Given_OpenApiDocument_Then_Type_Of_Property_Should_Return_Type_If_It_Is_BaseObject_Or_Not(string @ref, string propName,bool isBaseObject)
+        {
+            var schemas = this._doc["components"]["schemas"];
+
+            var type = schemas?[@ref]?["properties"]?[propName]?["type"]?.Value<string>() ;
+
+            if (isBaseObject)
+            {
+                type.Should().Be("object");
+            }
+            else
+            {
+                type.Should().NotBe("object");
+            }
+        }
+
+    }
+}

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Get_ApplicationJson_BaseObject_HttpTrigger.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Get_ApplicationJson_BaseObject_HttpTrigger.cs
@@ -1,0 +1,28 @@
+using System.Net;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp
+{
+    public static class Get_ApplicationJson_BaseObject_HttpTrigger
+    {
+        [FunctionName(nameof(Get_ApplicationJson_BaseObject_HttpTrigger))]
+        [OpenApiOperation(operationId: nameof(Get_ApplicationJson_BaseObject_HttpTrigger.Get_ApplicationJson_Object), tags: new[] { "greeting" })]
+        [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(HasBaseObjectModel), Description = "The OK response")]
+        public static async Task<IActionResult> Get_ApplicationJson_Object(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "GET", Route = "get-applicationjson-base-object")] HttpRequest req,
+            ILogger log)
+        {
+            var result  = new OkResult();
+
+            return await Task.FromResult(result).ConfigureAwait(false);
+        }
+    }
+}

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Models/HasBaseObjectModel.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Models/HasBaseObjectModel.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Models
+{
+    public class HasBaseObjectSubModel
+    {
+        public object SubObjectValue{ get; set; }
+    }
+    public class HasBaseObjectModel
+    {
+        public object ObjectValue { get; set; }
+        public int NonObjectValue { get; set; }
+        public HasBaseObjectSubModel SubModel { get; set; }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes/FakeModel.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes/FakeModel.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes
         [JsonProperty]
         public string FakePropertyNoAnnotation { get; set; }
 
+        public object FakeObject { get; set; }
+
         /// <summary>
         /// Gets or sets the nullable int value.
         /// </summary>

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/BaseObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/BaseObjectTypeVisitorTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+using FluentAssertions;
+
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors;
+using Microsoft.OpenApi.Any;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Newtonsoft.Json.Serialization;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
+{
+    [TestClass]
+    public class BaseObjectTypeVisitorTests
+    {
+        private VisitorCollection _visitorCollection;
+        private IVisitor _visitor;
+        private NamingStrategy _strategy;
+
+        [TestInitialize]
+        public void Init()
+        {
+            this._visitorCollection = new VisitorCollection();
+            this._visitor = new BaseObjectTypeVisitor(this._visitorCollection);
+            this._strategy = new CamelCaseNamingStrategy();
+        }
+
+        [DataTestMethod]
+        [DataRow(typeof(object), true)]
+        [DataRow(typeof(FakeModel), false)]
+        [DataRow(typeof(int), false)]
+        public void Given_Type_When_IsVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
+        {
+            var result = this._visitor.IsVisitable(type);
+
+            result.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(typeof(object), true)]
+        [DataRow(typeof(FakeModel), false)]
+        [DataRow(typeof(int), false)]
+        public void Given_Type_When_IsParameterVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
+        {
+            var result = this._visitor.IsParameterVisitable(type);
+
+            result.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(typeof(object), true)]
+        [DataRow(typeof(FakeModel), false)]
+        [DataRow(typeof(int), false)]
+        public void Given_Type_When_IsPayloadVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
+        {
+            var result = this._visitor.IsPayloadVisitable(type);
+
+            result.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow("object")]
+        public void Given_Type_When_Visit_Invoked_Then_It_Should_Return_Result(string dataType)
+        {
+            var name = "object";
+            var acceptor = new OpenApiSchemaAcceptor();
+            var type = new KeyValuePair<string, Type>(name, typeof(object));
+
+            this._visitor.Visit(acceptor, type, this._strategy);
+
+            acceptor.Schemas.Should().ContainKey(name);
+            acceptor.Schemas[name].Type.Should().Be(dataType);
+        }
+
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/BaseObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/BaseObjectTypeVisitorTests.cs
@@ -47,17 +47,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
         [DataRow(typeof(object), true)]
         [DataRow(typeof(FakeModel), false)]
         [DataRow(typeof(int), false)]
-        public void Given_Type_When_IsParameterVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
-        {
-            var result = this._visitor.IsParameterVisitable(type);
-
-            result.Should().Be(expected);
-        }
-
-        [DataTestMethod]
-        [DataRow(typeof(object), true)]
-        [DataRow(typeof(FakeModel), false)]
-        [DataRow(typeof(int), false)]
         public void Given_Type_When_IsPayloadVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
         {
             var result = this._visitor.IsPayloadVisitable(type);

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/ObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/ObjectTypeVisitorTests.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow(typeof(FakeModel), true)]
+        [DataRow(typeof(object), false)]
         [DataRow(typeof(int), false)]
         [DataRow(typeof(Uri), false)]
         [DataRow(typeof(IEnumerable<object>), false)]
@@ -57,6 +58,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
 
         [DataTestMethod]
         [DataRow(typeof(FakeModel), false)]
+        [DataRow(typeof(object), false)]
         [DataRow(typeof(int), false)]
         [DataRow(typeof(Uri), false)]
         [DataRow(typeof(IEnumerable<object>), false)]


### PR DESCRIPTION
This PR is related to issue #108 

What is this about:
- Support Base Object (root of all classes) type

What is include in the PR:
- Create BaseObjectTypeVisitor
- Modify ObjectTypeVisitor
- Unit Test Code
- Intergration Test Code
