### PR TITLE
HTTP/HTTPS in Swagger UI + oauth2+redirect.html

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Document.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Document.cs
@@ -14,6 +14,7 @@ using Microsoft.OpenApi.Models;
 using Newtonsoft.Json.Serialization;
 
 using GenericExtensions = Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions.GenericExtensions;
+using HttpRequestDataObjectExtensions = Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions.HttpRequestDataObjectExtensions;
 using OpenApiDocumentExtensions = Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions.OpenApiDocumentExtensions;
 using StringExtensions = Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions.StringExtensions;
 
@@ -73,7 +74,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi
             this._req = req;
 
             var prefix = string.IsNullOrWhiteSpace(routePrefix) ? string.Empty : $"/{routePrefix}";
-            var baseUrl = $"{this._req.Scheme}://{this._req.Host}{prefix}";
+            var baseUrl = $"{HttpRequestDataObjectExtensions.GetScheme(this._req, options)}://{this._req.Host}{prefix}";
 
             var server = new OpenApiServer { Url = baseUrl };
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.CLI/Microsoft.Azure.WebJobs.Extensions.OpenApi.CLI.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.CLI/Microsoft.Azure.WebJobs.Extensions.OpenApi.CLI.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>azfuncopenapi</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.OpenApi.CLI</RootNamespace>
   </PropertyGroup>

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IOpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IOpenApiConfigurationOptions.cs
@@ -29,5 +29,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions
         /// Gets or sets the value indicating whether to include the requesting hostname or not.
         /// </summary>
         bool IncludeRequestingHostName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating whether to force the HTTPS protocol or not.
+        /// </summary>
+        bool ForceHttps { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IOpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IOpenApiConfigurationOptions.cs
@@ -31,6 +31,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions
         bool IncludeRequestingHostName { get; set; }
 
         /// <summary>
+        /// Gets or sets the value indicating whether to force the HTTP protocol or not.
+        /// </summary>
+        bool ForceHttp { get; set; }
+
+        /// <summary>
         /// Gets or sets the value indicating whether to force the HTTPS protocol or not.
         /// </summary>
         bool ForceHttps { get; set; }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
         private const string OpenApiHostNamesKey = "OpenApi__HostNames";
         private const string OpenApiVersionKey = "OpenApi__Version";
         private const string FunctionsRuntimeEnvironmentKey = "AZURE_FUNCTIONS_ENVIRONMENT";
+        private const string ForceHttpKey = "OpenApi__ForceHttp";
         private const string ForceHttpsKey = "OpenApi__ForceHttps";
 
         /// <inheritdoc />
@@ -37,6 +38,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
 
         /// <inheritdoc />
         public virtual bool IncludeRequestingHostName { get; set; } = IsFunctionsRuntimeEnvironmentDevelopment();
+
+        /// <inheritdoc />
+        public bool ForceHttp { get; set; } = IsHttpForced();
 
         /// <inheritdoc />
         public bool ForceHttps { get; set; } = IsHttpsForced();
@@ -105,6 +109,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
         protected static bool IsFunctionsRuntimeEnvironmentDevelopment()
         {
             var development = Environment.GetEnvironmentVariable(FunctionsRuntimeEnvironmentKey) == "Development";
+
+            return development;
+        }
+
+        /// <summary>
+        /// Checks whether HTTP is forced or not.
+        /// </summary>
+        /// <returns>Returns <c>True</c>, if HTTP is forced; otherwise returns <c>False</c>.</returns>
+        protected static bool IsHttpForced()
+        {
+            var development = bool.TryParse(Environment.GetEnvironmentVariable(ForceHttpKey), out var result) ? result : false;;
 
             return development;
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
         private const string OpenApiHostNamesKey = "OpenApi__HostNames";
         private const string OpenApiVersionKey = "OpenApi__Version";
         private const string FunctionsRuntimeEnvironmentKey = "AZURE_FUNCTIONS_ENVIRONMENT";
+        private const string ForceHttpsKey = "OpenApi__ForceHttps";
 
         /// <inheritdoc />
         public virtual OpenApiInfo Info { get; set; } = new OpenApiInfo()
@@ -36,6 +37,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
 
         /// <inheritdoc />
         public virtual bool IncludeRequestingHostName { get; set; } = IsFunctionsRuntimeEnvironmentDevelopment();
+
+        /// <inheritdoc />
+        public bool ForceHttps { get; set; } = IsHttpsForced();
 
         /// <summary>
         /// Gets the OpenAPI document version.
@@ -101,6 +105,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
         protected static bool IsFunctionsRuntimeEnvironmentDevelopment()
         {
             var development = Environment.GetEnvironmentVariable(FunctionsRuntimeEnvironmentKey) == "Development";
+
+            return development;
+        }
+
+        /// <summary>
+        /// Checks whether HTTPS is forced or not.
+        /// </summary>
+        /// <returns>Returns <c>True</c>, if HTTPS is forced; otherwise returns <c>False</c>.</returns>
+        protected static bool IsHttpsForced()
+        {
+            var development = bool.TryParse(Environment.GetEnvironmentVariable(ForceHttpsKey), out var result) ? result : false;;
 
             return development;
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiSettings.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiSettings.cs
@@ -28,5 +28,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
 
         /// <inheritdoc />
         public bool IncludeRequestingHostName { get; set; }
+
+        /// <inheritdoc />
+        public bool ForceHttps { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiSettings.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiSettings.cs
@@ -30,6 +30,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
         public bool IncludeRequestingHostName { get; set; }
 
         /// <inheritdoc />
+        public bool ForceHttp { get; set; }
+
+        /// <inheritdoc />
         public bool ForceHttps { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/HttpRequestDataObjectExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/HttpRequestDataObjectExtensions.cs
@@ -1,0 +1,41 @@
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
+{
+    /// <summary>
+    /// This represents the extension entity for <see cref="IHttpRequestDataObject"/>.
+    /// </summary>
+    public static class HttpRequestDataObjectExtensions
+    {
+        private const string HTTP = "http";
+        private const string HTTPS = "https";
+
+        /// <summary>
+        /// Gets the scheme whether to return either HTTP or HTTPS depending on the condition.
+        /// /// </summary>
+        /// <param name="req"><see cref="IHttpRequestDataObject"/> instance.</param>
+        /// <param name="options"><see cref="IOpenApiConfigurationOptions"/> instance.</param>
+        /// <returns>Return either "HTTP" or "HTTPS", depending on the condition.</returns>
+        public static string GetScheme(this IHttpRequestDataObject req, IOpenApiConfigurationOptions options)
+        {
+            req.ThrowIfNullOrDefault();
+
+            if (options.IsNullOrDefault())
+            {
+                return req.Scheme;
+            }
+
+            if (options.ForceHttps)
+            {
+                return HTTPS;
+            }
+
+            if (options.ForceHttp)
+            {
+                return HTTP;
+            }
+
+            return req.Scheme;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/SwaggerUI.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/SwaggerUI.cs
@@ -59,10 +59,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
 
             var prefix = string.IsNullOrWhiteSpace(routePrefix) ? string.Empty : $"/{routePrefix}";
             var baseUrl = $"{this._req.GetScheme(options)}://{this._req.Host}{prefix}";
+            var absolutePath = default(string);
 
             if (options.IsNullOrDefault())
             {
                 this._baseUrl = baseUrl;
+
+                absolutePath = new Uri(this._baseUrl).AbsolutePath.Trim('/');
+                this._swaggerUiApiPrefix = absolutePath;
 
                 return this;
             }
@@ -84,7 +88,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
             }
 
             this._baseUrl = servers.First().Url;
-            this._swaggerUiApiPrefix = prefix;
+
+            absolutePath = new Uri(this._baseUrl).AbsolutePath.Trim('/');
+            this._swaggerUiApiPrefix = absolutePath;
 
             return this;
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/SwaggerUI.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/SwaggerUI.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -59,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
             this._req = req;
 
             var prefix = string.IsNullOrWhiteSpace(routePrefix) ? string.Empty : $"/{routePrefix}";
-            var baseUrl = $"{this._req.Scheme}://{this._req.Host}{prefix}";
+            var baseUrl = $"{this._req.GetScheme(options)}://{this._req.Host}{prefix}";
 
             if (options.IsNullOrDefault())
             {

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/Document.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/Document.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
             this._req = req;
 
             var prefix = string.IsNullOrWhiteSpace(routePrefix) ? string.Empty : $"/{routePrefix}";
-            var baseUrl = $"{this._req.Scheme}://{this._req.Host}{prefix}";
+            var baseUrl = $"{this._req.GetScheme(options)}://{this._req.Host}{prefix}";
 
             var server = new OpenApiServer { Url = baseUrl };
 

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/DocumentTests.cs
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/DocumentTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [DataRow("https", "localhost", 47071, null)]
         [DataRow("https", "localhost", 47071, "")]
         [DataRow("https", "localhost", 47071, "api")]
-        public void Given_NoOptions_When_AddMetadata_Invoked_Then_It_Should_Return_Result(string scheme, string host, int port, string routePrefix)
+        public void Given_NoOptions_When_AddServer_Invoked_Then_It_Should_Return_Result(string scheme, string host, int port, string routePrefix)
         {
             var helper = new Mock<IDocumentHelper>();
             var doc = new Document(helper.Object);
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [DataRow("https", "localhost", 47071, null)]
         [DataRow("https", "localhost", 47071, "")]
         [DataRow("https", "localhost", 47071, "api")]
-        public void Given_EmptyOptions_When_AddMetadata_Invoked_Then_It_Should_Return_Result(string scheme, string host, int port, string routePrefix)
+        public void Given_EmptyOptions_When_AddServer_Invoked_Then_It_Should_Return_Result(string scheme, string host, int port, string routePrefix)
         {
             var helper = new Mock<IDocumentHelper>();
             var doc = new Document(helper.Object);
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [DataRow("https", "localhost", 47071, null, "helloworld")]
         [DataRow("https", "localhost", 47071, "", "helloworld")]
         [DataRow("https", "localhost", 47071, "api", "helloworld")]
-        public void Given_ExtraServers_And_Include_When_AddMetadata_Invoked_Then_It_Should_Return_Result(string scheme, string host, int port, string routePrefix, string server)
+        public void Given_ExtraServers_And_Include_When_AddServer_Invoked_Then_It_Should_Return_Result(string scheme, string host, int port, string routePrefix, string server)
         {
             var helper = new Mock<IDocumentHelper>();
             var doc = new Document(helper.Object);
@@ -177,7 +177,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [DataRow("https", "localhost", 47071, null, "helloworld")]
         [DataRow("https", "localhost", 47071, "", "helloworld")]
         [DataRow("https", "localhost", 47071, "api", "helloworld")]
-        public void Given_ExtraServers_And_Exclude_When_AddMetadata_Invoked_Then_It_Should_Return_Result(string scheme, string host, int port, string routePrefix, string server)
+        public void Given_ExtraServers_And_Exclude_When_AddServer_Invoked_Then_It_Should_Return_Result(string scheme, string host, int port, string routePrefix, string server)
         {
             var helper = new Mock<IDocumentHelper>();
             var doc = new Document(helper.Object);
@@ -199,6 +199,109 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
 
             result.OpenApiDocument.Servers.Should().HaveCount(1);
             result.OpenApiDocument.Servers.First().Url.Should().Be(server);
+        }
+
+        [DataTestMethod]
+        [DataRow("http", "localhost", "api", "http://localhost/api")]
+        [DataRow("https", "localhost", "api", "https://localhost/api")]
+        [DataRow("http", "localhost:7071", "api", "http://localhost:7071/api")]
+        [DataRow("https", "localhost:47071", "api", "https://localhost:47071/api")]
+        [DataRow("http", "localhost", "", "http://localhost")]
+        [DataRow("https", "localhost", "", "https://localhost")]
+        [DataRow("http", "localhost:7071", "", "http://localhost:7071")]
+        [DataRow("https", "localhost:47071", "", "https://localhost:47071")]
+        [DataRow("http", "localhost", null, "http://localhost")]
+        [DataRow("https", "localhost", null, "https://localhost")]
+        [DataRow("http", "localhost:7071", null, "http://localhost:7071")]
+        [DataRow("https", "localhost:47071", null, "https://localhost:47071")]
+        public void Given_NullOptions_When_AddServer_Invoked_Then_It_Should_Return_BaseUrl(string scheme, string host, string routePrefix, string expected)
+        {
+            var helper = new Mock<IDocumentHelper>();
+            var doc = new Document(helper.Object);
+
+            var req = new Mock<IHttpRequestDataObject>();
+            req.SetupGet(p => p.Scheme).Returns(scheme);
+
+            var hostString = new HostString(host);
+            req.SetupGet(p => p.Host).Returns(hostString);
+
+            var result = doc.InitialiseDocument()
+                            .AddServer(req.Object, routePrefix, null);
+
+            result.OpenApiDocument.Servers.Should().HaveCount(1);
+            result.OpenApiDocument.Servers.First().Url.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow("http", "localhost", "api", true, true, "https://localhost/api")]
+        [DataRow("https", "localhost", "api", true, true, "https://localhost/api")]
+        [DataRow("http", "localhost:7071", "api", true, true, "https://localhost:7071/api")]
+        [DataRow("https", "localhost:47071", "api", true, true, "https://localhost:47071/api")]
+        [DataRow("http", "localhost", "", true, true, "https://localhost")]
+        [DataRow("https", "localhost", "", true, true, "https://localhost")]
+        [DataRow("http", "localhost:7071", "", true, true, "https://localhost:7071")]
+        [DataRow("https", "localhost:47071", "", true, true, "https://localhost:47071")]
+        [DataRow("http", "localhost", null, true, true, "https://localhost")]
+        [DataRow("https", "localhost", null, true, true, "https://localhost")]
+        [DataRow("http", "localhost:7071", null, true, true, "https://localhost:7071")]
+        [DataRow("https", "localhost:47071", null, true, true, "https://localhost:47071")]
+        [DataRow("http", "localhost", "api", true, false, "https://localhost/api")]
+        [DataRow("https", "localhost", "api", true, false, "https://localhost/api")]
+        [DataRow("http", "localhost:7071", "api", true, false, "https://localhost:7071/api")]
+        [DataRow("https", "localhost:47071", "api", true, false, "https://localhost:47071/api")]
+        [DataRow("http", "localhost", "", true, false, "https://localhost")]
+        [DataRow("https", "localhost", "", true, false, "https://localhost")]
+        [DataRow("http", "localhost:7071", "", true, false, "https://localhost:7071")]
+        [DataRow("https", "localhost:47071", "", true, false, "https://localhost:47071")]
+        [DataRow("http", "localhost", null, true, false, "https://localhost")]
+        [DataRow("https", "localhost", null, true, false, "https://localhost")]
+        [DataRow("http", "localhost:7071", null, true, false, "https://localhost:7071")]
+        [DataRow("https", "localhost:47071", null, true, false, "https://localhost:47071")]
+        [DataRow("http", "localhost", "api", false, true, "http://localhost/api")]
+        [DataRow("https", "localhost", "api", false, true, "http://localhost/api")]
+        [DataRow("http", "localhost:7071", "api", false, true, "http://localhost:7071/api")]
+        [DataRow("https", "localhost:47071", "api", false, true, "http://localhost:47071/api")]
+        [DataRow("http", "localhost", "", false, true, "http://localhost")]
+        [DataRow("https", "localhost", "", false, true, "http://localhost")]
+        [DataRow("http", "localhost:7071", "", false, true, "http://localhost:7071")]
+        [DataRow("https", "localhost:47071", "", false, true, "http://localhost:47071")]
+        [DataRow("http", "localhost", null, false, true, "http://localhost")]
+        [DataRow("https", "localhost", null, false, true, "http://localhost")]
+        [DataRow("http", "localhost:7071", null, false, true, "http://localhost:7071")]
+        [DataRow("https", "localhost:47071", null, false, true, "http://localhost:47071")]
+        [DataRow("http", "localhost", "api", false, false, "http://localhost/api")]
+        [DataRow("https", "localhost", "api", false, false, "https://localhost/api")]
+        [DataRow("http", "localhost:7071", "api", false, false, "http://localhost:7071/api")]
+        [DataRow("https", "localhost:47071", "api", false, false, "https://localhost:47071/api")]
+        [DataRow("http", "localhost", "", false, false, "http://localhost")]
+        [DataRow("https", "localhost", "", false, false, "https://localhost")]
+        [DataRow("http", "localhost:7071", "", false, false, "http://localhost:7071")]
+        [DataRow("https", "localhost:47071", "", false, false, "https://localhost:47071")]
+        [DataRow("http", "localhost", null, false, false, "http://localhost")]
+        [DataRow("https", "localhost", null, false, false, "https://localhost")]
+        [DataRow("http", "localhost:7071", null, false, false, "http://localhost:7071")]
+        [DataRow("https", "localhost:47071", null, false, false, "https://localhost:47071")]
+        public void Given_Options_When_AddServer_Invoked_Then_It_Should_Return_BaseUrl(string scheme, string host, string routePrefix, bool forceHttps, bool forceHttp, string expected)
+        {
+            var helper = new Mock<IDocumentHelper>();
+            var doc = new Document(helper.Object);
+
+            var req = new Mock<IHttpRequestDataObject>();
+            req.SetupGet(p => p.Scheme).Returns(scheme);
+
+            var hostString = new HostString(host);
+            req.SetupGet(p => p.Host).Returns(hostString);
+
+            var options = new Mock<IOpenApiConfigurationOptions>();
+            options.SetupGet(p => p.ForceHttps).Returns(forceHttps);
+            options.SetupGet(p => p.ForceHttp).Returns(forceHttp);
+            options.SetupGet(p => p.Servers).Returns(new List<OpenApiServer>());
+
+            var result = doc.InitialiseDocument()
+                            .AddServer(req.Object, routePrefix, options.Object);
+
+            result.OpenApiDocument.Servers.Should().HaveCount(1);
+            result.OpenApiDocument.Servers.First().Url.Should().Be(expected);
         }
 
         [TestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.CLI.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.CLI.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.CLI.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.CLI.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/DefaultOpenApiConfigurationOptionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/DefaultOpenApiConfigurationOptionsTests.cs
@@ -193,6 +193,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
         [DataRow("false", false)]
         [DataRow("", false)]
         [DataRow(null, false)]
+        public void Given_EnvironmentVariable_When_IsHttpForced_Invoked_Then_It_Should_Return_Result(string forceHttps, bool expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__ForceHttp", forceHttps);
+
+            var options = new DefaultOpenApiConfigurationOptions();
+            var method = typeof(DefaultOpenApiConfigurationOptions).GetMethod("IsHttpForced", BindingFlags.NonPublic | BindingFlags.Static);
+
+            var result = method.Invoke(options, null);
+
+            result.Should().BeOfType<bool>();
+            ((bool)result).Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow("true", true)]
+        [DataRow("false", false)]
+        [DataRow("", false)]
+        [DataRow(null, false)]
         public void Given_EnvironmentVariable_When_IsHttpsForced_Invoked_Then_It_Should_Return_Result(string forceHttps, bool expected)
         {
             Environment.SetEnvironmentVariable("OpenApi__ForceHttps", forceHttps);

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/DefaultOpenApiConfigurationOptionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/DefaultOpenApiConfigurationOptionsTests.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using FluentAssertions;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.OpenApi.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -160,7 +159,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
         [DataRow("V2", OpenApiVersionType.V2)]
         [DataRow("v3", OpenApiVersionType.V3)]
         [DataRow("V3", OpenApiVersionType.V3)]
-        public void Given_EnvironmentVariable_When_GetHostNames_Invoked_Then_It_Should_Return_Result(string version, OpenApiVersionType expected)
+        public void Given_EnvironmentVariable_When_GetOpenApiVersion_Invoked_Then_It_Should_Return_Result(string version, OpenApiVersionType expected)
         {
             Environment.SetEnvironmentVariable("OpenApi__Version", version);
 
@@ -176,12 +175,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
         [DataTestMethod]
         [DataRow("Development", true)]
         [DataRow("Production", false)]
-        public void Given_EnvironmentVariable_When_GetHostNames_Invoked_Then_It_Should_Return_Result(string environment, bool expected)
+        public void Given_EnvironmentVariable_When_IsFunctionsRuntimeEnvironmentDevelopment_Invoked_Then_It_Should_Return_Result(string environment, bool expected)
         {
             Environment.SetEnvironmentVariable("AZURE_FUNCTIONS_ENVIRONMENT", environment);
 
             var options = new DefaultOpenApiConfigurationOptions();
             var method = typeof(DefaultOpenApiConfigurationOptions).GetMethod("IsFunctionsRuntimeEnvironmentDevelopment", BindingFlags.NonPublic | BindingFlags.Static);
+
+            var result = method.Invoke(options, null);
+
+            result.Should().BeOfType<bool>();
+            ((bool)result).Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow("true", true)]
+        [DataRow("false", false)]
+        [DataRow("", false)]
+        [DataRow(null, false)]
+        public void Given_EnvironmentVariable_When_IsHttpsForced_Invoked_Then_It_Should_Return_Result(string forceHttps, bool expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__ForceHttps", forceHttps);
+
+            var options = new DefaultOpenApiConfigurationOptions();
+            var method = typeof(DefaultOpenApiConfigurationOptions).GetMethod("IsHttpsForced", BindingFlags.NonPublic | BindingFlags.Static);
 
             var result = method.Invoke(options, null);
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/EnumExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/EnumExtensionsTests.cs
@@ -1,11 +1,10 @@
 using System;
 
+using FluentAssertions;
+
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes;
-
-using FluentAssertions;
-
 using Microsoft.OpenApi;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/HttpRequestDataObjectExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/HttpRequestDataObjectExtensionsTests.cs
@@ -1,0 +1,60 @@
+using System;
+
+using FluentAssertions;
+
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
+{
+    [TestClass]
+    public class HttpRequestDataObjectExtensionsTests
+    {
+        [TestMethod]
+        public void Given_Null_When_GetScheme_Invoked_Then_It_Should_Throw_Exception()
+        {
+            Action action = () => HttpRequestDataObjectExtensions.GetScheme(null, null);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [DataTestMethod]
+        [DataRow("http", "http")]
+        [DataRow("https", "https")]
+        public void Given_NullOptions_When_GetScheme_Invoked_Then_It_Should_Return_Result(string scheme, string expected)
+        {
+            var req = new Mock<IHttpRequestDataObject>();
+            req.SetupGet(p => p.Scheme).Returns(scheme);
+
+            var result = HttpRequestDataObjectExtensions.GetScheme(req.Object, null);
+
+            result.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow("http", true, true, "https")]
+        [DataRow("http", true, false, "https")]
+        [DataRow("http", false, true, "http")]
+        [DataRow("http", false, false, "http")]
+        [DataRow("https", true, true, "https")]
+        [DataRow("https", true, false, "https")]
+        [DataRow("https", false, true, "http")]
+        [DataRow("https", false, false, "https")]
+        public void Given_Options_When_GetScheme_Invoked_Then_It_Should_Return_Result(string scheme, bool forceHttps, bool forceHttp, string expected)
+        {
+            var req = new Mock<IHttpRequestDataObject>();
+            req.SetupGet(p => p.Scheme).Returns(scheme);
+
+            var options = new Mock<IOpenApiConfigurationOptions>();
+            options.SetupGet(p => p.ForceHttps).Returns(forceHttps);
+            options.SetupGet(p => p.ForceHttp).Returns(forceHttp);
+
+            var result = HttpRequestDataObjectExtensions.GetScheme(req.Object, options.Object);
+
+            result.Should().Be(expected);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/SwaggerUITests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/SwaggerUITests.cs
@@ -1,0 +1,119 @@
+using System.Collections.Generic;
+using System.Reflection;
+
+using FluentAssertions;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.OpenApi.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
+{
+    [TestClass]
+    public class SwaggerUITests
+    {
+        [DataTestMethod]
+        [DataRow("http", "localhost", "api", "http://localhost/api")]
+        [DataRow("https", "localhost", "api", "https://localhost/api")]
+        [DataRow("http", "localhost:7071", "api", "http://localhost:7071/api")]
+        [DataRow("https", "localhost:47071", "api", "https://localhost:47071/api")]
+        [DataRow("http", "localhost", "", "http://localhost")]
+        [DataRow("https", "localhost", "", "https://localhost")]
+        [DataRow("http", "localhost:7071", "", "http://localhost:7071")]
+        [DataRow("https", "localhost:47071", "", "https://localhost:47071")]
+        [DataRow("http", "localhost", null, "http://localhost")]
+        [DataRow("https", "localhost", null, "https://localhost")]
+        [DataRow("http", "localhost:7071", null, "http://localhost:7071")]
+        [DataRow("https", "localhost:47071", null, "https://localhost:47071")]
+        public void Given_NullOptions_When_AddServer_Invoked_Then_It_Should_Return_BaseUrl(string scheme, string host, string routePrefix, string expected)
+        {
+            var req = new Mock<IHttpRequestDataObject>();
+            req.SetupGet(p => p.Scheme).Returns(scheme);
+
+            var hostString = new HostString(host);
+            req.SetupGet(p => p.Host).Returns(hostString);
+
+            var ui = new SwaggerUI();
+
+            ui.AddServer(req.Object, routePrefix, null);
+
+            var fi = ui.GetType().GetField("_baseUrl", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            (fi.GetValue(ui) as string).Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow("http", "localhost", "api", true, true, "https://localhost/api")]
+        [DataRow("https", "localhost", "api", true, true, "https://localhost/api")]
+        [DataRow("http", "localhost:7071", "api", true, true, "https://localhost:7071/api")]
+        [DataRow("https", "localhost:47071", "api", true, true, "https://localhost:47071/api")]
+        [DataRow("http", "localhost", "", true, true, "https://localhost")]
+        [DataRow("https", "localhost", "", true, true, "https://localhost")]
+        [DataRow("http", "localhost:7071", "", true, true, "https://localhost:7071")]
+        [DataRow("https", "localhost:47071", "", true, true, "https://localhost:47071")]
+        [DataRow("http", "localhost", null, true, true, "https://localhost")]
+        [DataRow("https", "localhost", null, true, true, "https://localhost")]
+        [DataRow("http", "localhost:7071", null, true, true, "https://localhost:7071")]
+        [DataRow("https", "localhost:47071", null, true, true, "https://localhost:47071")]
+        [DataRow("http", "localhost", "api", true, false, "https://localhost/api")]
+        [DataRow("https", "localhost", "api", true, false, "https://localhost/api")]
+        [DataRow("http", "localhost:7071", "api", true, false, "https://localhost:7071/api")]
+        [DataRow("https", "localhost:47071", "api", true, false, "https://localhost:47071/api")]
+        [DataRow("http", "localhost", "", true, false, "https://localhost")]
+        [DataRow("https", "localhost", "", true, false, "https://localhost")]
+        [DataRow("http", "localhost:7071", "", true, false, "https://localhost:7071")]
+        [DataRow("https", "localhost:47071", "", true, false, "https://localhost:47071")]
+        [DataRow("http", "localhost", null, true, false, "https://localhost")]
+        [DataRow("https", "localhost", null, true, false, "https://localhost")]
+        [DataRow("http", "localhost:7071", null, true, false, "https://localhost:7071")]
+        [DataRow("https", "localhost:47071", null, true, false, "https://localhost:47071")]
+        [DataRow("http", "localhost", "api", false, true, "http://localhost/api")]
+        [DataRow("https", "localhost", "api", false, true, "http://localhost/api")]
+        [DataRow("http", "localhost:7071", "api", false, true, "http://localhost:7071/api")]
+        [DataRow("https", "localhost:47071", "api", false, true, "http://localhost:47071/api")]
+        [DataRow("http", "localhost", "", false, true, "http://localhost")]
+        [DataRow("https", "localhost", "", false, true, "http://localhost")]
+        [DataRow("http", "localhost:7071", "", false, true, "http://localhost:7071")]
+        [DataRow("https", "localhost:47071", "", false, true, "http://localhost:47071")]
+        [DataRow("http", "localhost", null, false, true, "http://localhost")]
+        [DataRow("https", "localhost", null, false, true, "http://localhost")]
+        [DataRow("http", "localhost:7071", null, false, true, "http://localhost:7071")]
+        [DataRow("https", "localhost:47071", null, false, true, "http://localhost:47071")]
+        [DataRow("http", "localhost", "api", false, false, "http://localhost/api")]
+        [DataRow("https", "localhost", "api", false, false, "https://localhost/api")]
+        [DataRow("http", "localhost:7071", "api", false, false, "http://localhost:7071/api")]
+        [DataRow("https", "localhost:47071", "api", false, false, "https://localhost:47071/api")]
+        [DataRow("http", "localhost", "", false, false, "http://localhost")]
+        [DataRow("https", "localhost", "", false, false, "https://localhost")]
+        [DataRow("http", "localhost:7071", "", false, false, "http://localhost:7071")]
+        [DataRow("https", "localhost:47071", "", false, false, "https://localhost:47071")]
+        [DataRow("http", "localhost", null, false, false, "http://localhost")]
+        [DataRow("https", "localhost", null, false, false, "https://localhost")]
+        [DataRow("http", "localhost:7071", null, false, false, "http://localhost:7071")]
+        [DataRow("https", "localhost:47071", null, false, false, "https://localhost:47071")]
+        public void Given_Options_When_AddServer_Invoked_Then_It_Should_Return_BaseUrl(string scheme, string host, string routePrefix, bool forceHttps, bool forceHttp, string expected)
+        {
+            var req = new Mock<IHttpRequestDataObject>();
+            req.SetupGet(p => p.Scheme).Returns(scheme);
+
+            var hostString = new HostString(host);
+            req.SetupGet(p => p.Host).Returns(hostString);
+
+            var options = new Mock<IOpenApiConfigurationOptions>();
+            options.SetupGet(p => p.ForceHttps).Returns(forceHttps);
+            options.SetupGet(p => p.ForceHttp).Returns(forceHttp);
+            options.SetupGet(p => p.Servers).Returns(new List<OpenApiServer>());
+
+            var ui = new SwaggerUI();
+
+            ui.AddServer(req.Object, routePrefix, options.Object);
+
+            var fi = ui.GetType().GetField("_baseUrl", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            (fi.GetValue(ui) as string).Should().Be(expected);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/SwaggerUITests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/SwaggerUITests.cs
@@ -115,5 +115,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
 
             (fi.GetValue(ui) as string).Should().Be(expected);
         }
+
+        [DataTestMethod]
+        [DataRow("http", "localhost", "api", "api")]
+        [DataRow("https", "localhost", "api/", "api")]
+        [DataRow("http", "localhost", "api/prod", "api/prod")]
+        [DataRow("https", "localhost", "api/prod/", "api/prod")]
+        public void Given_NullOptions_When_AddServer_Invoked_Then_It_Should_Return_SwaggerUIApiPrefix(string scheme, string host, string routePrefix, string expected)
+        {
+            var req = new Mock<IHttpRequestDataObject>();
+            req.SetupGet(p => p.Scheme).Returns(scheme);
+
+            var hostString = new HostString(host);
+            req.SetupGet(p => p.Host).Returns(hostString);
+
+            var ui = new SwaggerUI();
+
+            ui.AddServer(req.Object, routePrefix, null);
+
+            var fi = ui.GetType().GetField("_swaggerUiApiPrefix", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            (fi.GetValue(ui) as string).Should().Be(expected);
+        }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/DocumentTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/DocumentTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests
         [DataRow("https", "localhost", 47071, null)]
         [DataRow("https", "localhost", 47071, "")]
         [DataRow("https", "localhost", 47071, "api")]
-        public void Given_NoOptions_When_AddMetadata_Invoked_Then_It_Should_Return_Result(string scheme, string host, int port, string routePrefix)
+        public void Given_NoOptions_When_AddServer_Invoked_Then_It_Should_Return_Result(string scheme, string host, int port, string routePrefix)
         {
             var helper = new Mock<IDocumentHelper>();
             var doc = new Document(helper.Object);
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests
         [DataRow("https", "localhost", 47071, null)]
         [DataRow("https", "localhost", 47071, "")]
         [DataRow("https", "localhost", 47071, "api")]
-        public void Given_EmptyOptions_When_AddMetadata_Invoked_Then_It_Should_Return_Result(string scheme, string host, int port, string routePrefix)
+        public void Given_EmptyOptions_When_AddServer_Invoked_Then_It_Should_Return_Result(string scheme, string host, int port, string routePrefix)
         {
             var helper = new Mock<IDocumentHelper>();
             var doc = new Document(helper.Object);
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests
         [DataRow("https", "localhost", 47071, null, "helloworld")]
         [DataRow("https", "localhost", 47071, "", "helloworld")]
         [DataRow("https", "localhost", 47071, "api", "helloworld")]
-        public void Given_ExtraServers_And_Include_When_AddMetadata_Invoked_Then_It_Should_Return_Result(string scheme, string host, int port, string routePrefix, string server)
+        public void Given_ExtraServers_And_Include_When_AddServer_Invoked_Then_It_Should_Return_Result(string scheme, string host, int port, string routePrefix, string server)
         {
             var helper = new Mock<IDocumentHelper>();
             var doc = new Document(helper.Object);
@@ -177,7 +177,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests
         [DataRow("https", "localhost", 47071, null, "helloworld")]
         [DataRow("https", "localhost", 47071, "", "helloworld")]
         [DataRow("https", "localhost", 47071, "api", "helloworld")]
-        public void Given_ExtraServers_And_Exclude_When_AddMetadata_Invoked_Then_It_Should_Return_Result(string scheme, string host, int port, string routePrefix, string server)
+        public void Given_ExtraServers_And_Exclude_When_AddServer_Invoked_Then_It_Should_Return_Result(string scheme, string host, int port, string routePrefix, string server)
         {
             var helper = new Mock<IDocumentHelper>();
             var doc = new Document(helper.Object);
@@ -199,6 +199,109 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests
 
             result.OpenApiDocument.Servers.Should().HaveCount(1);
             result.OpenApiDocument.Servers.First().Url.Should().Be(server);
+        }
+
+        [DataTestMethod]
+        [DataRow("http", "localhost", "api", "http://localhost/api")]
+        [DataRow("https", "localhost", "api", "https://localhost/api")]
+        [DataRow("http", "localhost:7071", "api", "http://localhost:7071/api")]
+        [DataRow("https", "localhost:47071", "api", "https://localhost:47071/api")]
+        [DataRow("http", "localhost", "", "http://localhost")]
+        [DataRow("https", "localhost", "", "https://localhost")]
+        [DataRow("http", "localhost:7071", "", "http://localhost:7071")]
+        [DataRow("https", "localhost:47071", "", "https://localhost:47071")]
+        [DataRow("http", "localhost", null, "http://localhost")]
+        [DataRow("https", "localhost", null, "https://localhost")]
+        [DataRow("http", "localhost:7071", null, "http://localhost:7071")]
+        [DataRow("https", "localhost:47071", null, "https://localhost:47071")]
+        public void Given_NullOptions_When_AddServer_Invoked_Then_It_Should_Return_BaseUrl(string scheme, string host, string routePrefix, string expected)
+        {
+            var helper = new Mock<IDocumentHelper>();
+            var doc = new Document(helper.Object);
+
+            var req = new Mock<IHttpRequestDataObject>();
+            req.SetupGet(p => p.Scheme).Returns(scheme);
+
+            var hostString = new HostString(host);
+            req.SetupGet(p => p.Host).Returns(hostString);
+
+            var result = doc.InitialiseDocument()
+                            .AddServer(req.Object, routePrefix, null);
+
+            result.OpenApiDocument.Servers.Should().HaveCount(1);
+            result.OpenApiDocument.Servers.First().Url.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow("http", "localhost", "api", true, true, "https://localhost/api")]
+        [DataRow("https", "localhost", "api", true, true, "https://localhost/api")]
+        [DataRow("http", "localhost:7071", "api", true, true, "https://localhost:7071/api")]
+        [DataRow("https", "localhost:47071", "api", true, true, "https://localhost:47071/api")]
+        [DataRow("http", "localhost", "", true, true, "https://localhost")]
+        [DataRow("https", "localhost", "", true, true, "https://localhost")]
+        [DataRow("http", "localhost:7071", "", true, true, "https://localhost:7071")]
+        [DataRow("https", "localhost:47071", "", true, true, "https://localhost:47071")]
+        [DataRow("http", "localhost", null, true, true, "https://localhost")]
+        [DataRow("https", "localhost", null, true, true, "https://localhost")]
+        [DataRow("http", "localhost:7071", null, true, true, "https://localhost:7071")]
+        [DataRow("https", "localhost:47071", null, true, true, "https://localhost:47071")]
+        [DataRow("http", "localhost", "api", true, false, "https://localhost/api")]
+        [DataRow("https", "localhost", "api", true, false, "https://localhost/api")]
+        [DataRow("http", "localhost:7071", "api", true, false, "https://localhost:7071/api")]
+        [DataRow("https", "localhost:47071", "api", true, false, "https://localhost:47071/api")]
+        [DataRow("http", "localhost", "", true, false, "https://localhost")]
+        [DataRow("https", "localhost", "", true, false, "https://localhost")]
+        [DataRow("http", "localhost:7071", "", true, false, "https://localhost:7071")]
+        [DataRow("https", "localhost:47071", "", true, false, "https://localhost:47071")]
+        [DataRow("http", "localhost", null, true, false, "https://localhost")]
+        [DataRow("https", "localhost", null, true, false, "https://localhost")]
+        [DataRow("http", "localhost:7071", null, true, false, "https://localhost:7071")]
+        [DataRow("https", "localhost:47071", null, true, false, "https://localhost:47071")]
+        [DataRow("http", "localhost", "api", false, true, "http://localhost/api")]
+        [DataRow("https", "localhost", "api", false, true, "http://localhost/api")]
+        [DataRow("http", "localhost:7071", "api", false, true, "http://localhost:7071/api")]
+        [DataRow("https", "localhost:47071", "api", false, true, "http://localhost:47071/api")]
+        [DataRow("http", "localhost", "", false, true, "http://localhost")]
+        [DataRow("https", "localhost", "", false, true, "http://localhost")]
+        [DataRow("http", "localhost:7071", "", false, true, "http://localhost:7071")]
+        [DataRow("https", "localhost:47071", "", false, true, "http://localhost:47071")]
+        [DataRow("http", "localhost", null, false, true, "http://localhost")]
+        [DataRow("https", "localhost", null, false, true, "http://localhost")]
+        [DataRow("http", "localhost:7071", null, false, true, "http://localhost:7071")]
+        [DataRow("https", "localhost:47071", null, false, true, "http://localhost:47071")]
+        [DataRow("http", "localhost", "api", false, false, "http://localhost/api")]
+        [DataRow("https", "localhost", "api", false, false, "https://localhost/api")]
+        [DataRow("http", "localhost:7071", "api", false, false, "http://localhost:7071/api")]
+        [DataRow("https", "localhost:47071", "api", false, false, "https://localhost:47071/api")]
+        [DataRow("http", "localhost", "", false, false, "http://localhost")]
+        [DataRow("https", "localhost", "", false, false, "https://localhost")]
+        [DataRow("http", "localhost:7071", "", false, false, "http://localhost:7071")]
+        [DataRow("https", "localhost:47071", "", false, false, "https://localhost:47071")]
+        [DataRow("http", "localhost", null, false, false, "http://localhost")]
+        [DataRow("https", "localhost", null, false, false, "https://localhost")]
+        [DataRow("http", "localhost:7071", null, false, false, "http://localhost:7071")]
+        [DataRow("https", "localhost:47071", null, false, false, "https://localhost:47071")]
+        public void Given_Options_When_AddServer_Invoked_Then_It_Should_Return_BaseUrl(string scheme, string host, string routePrefix, bool forceHttps, bool forceHttp, string expected)
+        {
+            var helper = new Mock<IDocumentHelper>();
+            var doc = new Document(helper.Object);
+
+            var req = new Mock<IHttpRequestDataObject>();
+            req.SetupGet(p => p.Scheme).Returns(scheme);
+
+            var hostString = new HostString(host);
+            req.SetupGet(p => p.Host).Returns(hostString);
+
+            var options = new Mock<IOpenApiConfigurationOptions>();
+            options.SetupGet(p => p.ForceHttps).Returns(forceHttps);
+            options.SetupGet(p => p.ForceHttp).Returns(forceHttp);
+            options.SetupGet(p => p.Servers).Returns(new List<OpenApiServer>());
+
+            var result = doc.InitialiseDocument()
+                            .AddServer(req.Object, routePrefix, options.Object);
+
+            result.OpenApiDocument.Servers.Should().HaveCount(1);
+            result.OpenApiDocument.Servers.First().Url.Should().Be(expected);
         }
 
         [TestMethod]


### PR DESCRIPTION
Related to: #215 #244 

This PR is:

* To force HTTP or HTTPS regardless the current HTTP protocol is. This is particularly useful for the Linux dedicated plan.
* To add proper prefix onto `oauth2-redirect.html`, considering the custom base URL.