### PR TITLE
Fixed throwing StackOverflowException when contains exception model

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiSchemaExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiSchemaExtensions.cs
@@ -307,6 +307,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
                 return false;
             }
 
+            if (schema.Title?.ToLower().EndsWith("exception") == true)
+            {
+                return false;
+            }
+
             if (!schema.Format.IsNullOrWhiteSpace())
             {
                 return false;

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
@@ -275,6 +275,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
         }
 
         /// <summary>
+        /// Checks whether the given type is exception or not, from the OpenAPI perspective.
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> instance.</param>
+        /// <returns>Returns <c>True</c>, if the type is identified as exception; otherwise returns <c>False</c>.</returns>
+        public static bool IsOpenApiException(this Type type)
+        {
+            if (type.IsNullOrDefault())
+            {
+                return false;
+            }
+
+            return type.IsExceptionType();
+        }
+
+        /// <summary>
         /// Checks whether the given type is array or not, from the OpenAPI perspective.
         /// </summary>
         /// <param name="type"><see cref="Type"/> instance.</param>
@@ -669,6 +684,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
             "IReadOnlyDictionary`2",
             "KeyValuePair`2",
         };
+
+        public static bool IsExceptionType(this Type type)
+        {
+            if (type == null)
+            {
+                return false;
+            }
+
+            if (type == typeof(Exception))
+            {
+                return true;
+            }
+
+            return IsExceptionType(type.BaseType);
+        }
 
         private static bool IsDictionaryType(this Type type)
         {

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
@@ -149,6 +149,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
                 return false;
             }
 
+            if (type.IsOpenApiException())
+            {
+                return false;
+            }
+
             return true;
         }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/RecursiveObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/RecursiveObjectTypeVisitor.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
         public override bool IsVisitable(Type type)
         {
             var isVisitable = this.IsVisitable(type, TypeCode.Object) && type.HasRecursiveProperty();
+
             if (type == typeof(Guid))
             {
                 isVisitable = false;
@@ -55,7 +56,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
             {
                 isVisitable = false;
             }
-
 
             return isVisitable;
         }
@@ -141,6 +141,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
             }
 
             if (type.IsOpenApiDictionary())
+            {
+                return false;
+            }
+
+            if (type.IsOpenApiException())
             {
                 return false;
             }

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_ApplicationJson_GenericAndRecursive_Tests.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_ApplicationJson_GenericAndRecursive_Tests.cs
@@ -1,0 +1,82 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
+{
+    [TestClass]
+    [TestCategory(Constants.TestCategory)]
+    public class Get_ApplicationJson_GenericAndRecursive_Tests
+    {
+        private static HttpClient http = new HttpClient();
+
+        private JObject _doc;
+
+        [TestInitialize]
+        public async Task Init()
+        {
+            var json = await http.GetStringAsync(Constants.OpenApiDocEndpoint).ConfigureAwait(false);
+            this._doc = JsonConvert.DeserializeObject<JObject>(json);
+        }
+
+        [DataTestMethod]
+        [DataRow("/get-applicationjson-genericandrecursive", "get", "200")]
+        public void Given_OpenApiDocument_Then_It_Should_Return_OperationResponse(string path, string operationType, string responseCode)
+        {
+            var responses = this._doc["paths"][path][operationType]["responses"];
+
+            responses[responseCode].Should().NotBeNull();
+        }
+
+        [DataTestMethod]
+        [DataRow("/get-applicationjson-genericandrecursive", "get", "200", "application/json")]
+        public void Given_OpenApiDocument_Then_It_Should_Return_OperationResponseContentType(string path, string operationType, string responseCode, string contentType)
+        {
+            var content = this._doc["paths"][path][operationType]["responses"][responseCode]["content"];
+
+            content[contentType].Should().NotBeNull();
+        }
+
+        [DataTestMethod]
+        [DataRow("/get-applicationjson-genericandrecursive", "get", "200", "application/json", "genericAndRecursiveModel")]
+        public void Given_OpenApiDocument_Then_It_Should_Return_OperationResponseContentTypeSchema(string path, string operationType, string responseCode, string contentType, string reference)
+        {
+            var content = this._doc["paths"][path][operationType]["responses"][responseCode]["content"];
+
+            var @ref = content[contentType]["schema"]["$ref"];
+
+            @ref.Value<string>().Should().Be($"#/components/schemas/{reference}");
+        }
+        [DataTestMethod]
+        [DataRow("genericAndRecursiveModel", "object")]
+        public void Given_OpenApiDocument_Then_It_Should_Return_ComponentSchema(string @ref, string refType)
+        {
+            var schemas = this._doc["components"]["schemas"];
+
+            var schema = schemas[@ref];
+
+            schema.Should().NotBeNull();
+            schema.Value<string>("type").Should().Be(refType);
+        }
+
+        [DataTestMethod]
+        [DataRow("genericAndRecursiveModel", "children", "array")]
+        [DataRow("genericAndRecursiveModel", "children2", "object")]
+        [DataRow("genericAndRecursiveModel", "exception", "object")]
+        public void Given_OpenApiDocument_Then_It_Should_Return_ComponentSchemaProperty(string @ref, string propertyName, string propertyType)
+        {
+            var properties = this._doc["components"]["schemas"][@ref]["properties"];
+
+            var value = properties[propertyName];
+
+            value.Should().NotBeNull();
+            value.Value<string>("type").Should().Be(propertyType);
+        }
+    }
+}

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Get_ApplicationJson_GenericAndRecursive_HttpTrigger.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Get_ApplicationJson_GenericAndRecursive_HttpTrigger.cs
@@ -6,7 +6,6 @@ using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Models;
 using Microsoft.Extensions.Logging;
-using Microsoft.OpenApi.Models;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp
 {

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Models/ByteArrayObjectModel.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Models/ByteArrayObjectModel.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Models
 {
     public class ByteArrayObjectModel

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Models/DoubleObjectModel.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Models/DoubleObjectModel.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Models
 {
     public class DoubleObjectModel

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Models/GenericAndRecursiveModel.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Models/GenericAndRecursiveModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Models
 {
@@ -8,5 +9,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Models
 
         public Dictionary<string, GenericAndRecursiveModel> Children2 { get; set; }
 
+        public Exception Exception { get; set; }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/TypeExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/TypeExtensionsTests.cs
@@ -171,6 +171,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
             result.Should().Be(expected);
         }
 
+        [DataTestMethod]
+        [DataRow(typeof(Exception), true)]
+        [DataRow(typeof(NullReferenceException), true)]
+        [DataRow(typeof(StackOverflowException), true)]
+        [DataRow(typeof(AggregateException), true)]
+        [DataRow(typeof(ArgumentException), true)]
+        public void Given_Type_When_IsExceptionType_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
+        {
+            var result = TypeExtensions.IsExceptionType(type);
+
+            result.Should().Be(expected);
+        }
+
         [TestMethod]
         public void Given_Null_When_HasInterface_Invoked_Then_It_Should_Return_False()
         {


### PR DESCRIPTION
This PR is that the Exception model ignores navigate types.

So, the Exception model doesn't navigate child properties.

Related https://github.com/Azure/azure-functions-openapi-extension/issues/251