### PR TITLE
Add new namespace at a core/ISwaggerUI.cs

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/ISwaggerUI.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/ISwaggerUI.cs
@@ -3,13 +3,14 @@ using System.Threading.Tasks;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.OpenApi.Models;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions
 {
     /// <summary>
     /// This provides interfaces to the <see cref="SwaggerUI"/> class.
     /// </summary>
-    public interface ISwaggerUI
+    public interface ISwaggerUI : IServiceCollection
     {
         /// <summary>
         /// Adds metadata to build OpenAPI document.

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/SwaggerUI.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/SwaggerUI.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -7,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
 using Microsoft.OpenApi.Models;
 
@@ -43,6 +46,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
         private string _swaggerUiApiPrefix;
         private string _indexHtml;
         private string _oauth2RedirectHtml;
+
+        public int Count => throw new NotImplementedException();
+
+        public bool IsReadOnly => throw new NotImplementedException();
+
+        public ServiceDescriptor this[int index] { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
         /// <inheritdoc />
         public ISwaggerUI AddMetadata(OpenApiInfo info)
@@ -223,6 +232,56 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
             }
 
             return true;
+        }
+
+        public int IndexOf(ServiceDescriptor item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Insert(int index, ServiceDescriptor item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Add(ServiceDescriptor item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Contains(ServiceDescriptor item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void CopyTo(ServiceDescriptor[] array, int arrayIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Remove(ServiceDescriptor item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerator<ServiceDescriptor> GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
안녕하세요 저스틴님 현재 #132  번 작업 진행 중이며 리뷰 부탁드리고자 PR 보냅니다. 
add new namespace 커밋만 확인해주시면 됩니다.

현재 코드 분석중인데 OpenApiTriggerFunctions.cs 파일 204번 라인에서 context.PackageAssembly 가 문제인 것으로 생각되며 PackageAssembly 는 OpenApiHTTPTriggerContext.cs 의 314번 라인의 GetAssembly 을 사용하여 Microsoft.Azure.Webjobs.Extensions.OpenApi.core.dll 을 가져오는 것 같습니다.

그런데, 이 dll 파일에는 addHealthCheck 정보를 확인할 수 있는 정보가 없어서 이 메소드를 가지고 있는 IServiceCollection 인터페이스의 네임스페이스인 Microsoft.Extensions.DependencyInjection 를 ISwaggerUI 에 포함시키고 ISwaggerUI 가 IServiceCollection 을 상속하도록만 만들어놓은 상태입니다.

현재 제가 접근하는 방식이 맞는지 불확실하여 확인 부탁드립니다. 