### PR TITLE
Ability to extend IDocument at runtime

### DIFF
--- a/docs/extending-openapi-spec.md
+++ b/docs/extending-openapi-spec.md
@@ -1,0 +1,100 @@
+# Extending or Modifying the OpenApi Spec at Runtime #
+
+By default, the Azure Functions OpenAPI extensions will locate HTTP function triggers automatically and generate an OpenApi spec
+with the appropriate endpoints and descriptions.  However, it is also possible to manipulate the generated spec at runtime before
+it is rendered to the client.  This can be done by adding implementations of `IDocumentExtension` to the service collection.
+
+## The `IDocumentExtension` Interface ##
+
+This interface has a single method, which takes an `IDocument` and `HttpRequest` and returns the modified document:
+
+```
+public interface IDocumentExtension
+{
+    IDocument ExtendDocument(IDocument document, HttpRequest request);
+}
+```
+
+For example, to add an endpoint called `/dummy` to the OpenApi spec with a single *GET* operation which returns a JSON response,
+the following implementation could be used:
+
+```
+public class DummyDocumentExtension : IDocumentExtension
+{
+    public IDocument ExtendDocument(IDocument document, HttpRequest request)
+    {
+        var okResponse = new OpenApiResponse
+        {
+            Description = "Dummy document extension",
+        };
+        
+        okResponse.Content.Add("application/json", new OpenApiMediaType
+        {
+            Schema = new OpenApiSchema
+            {
+                Type = "json"
+            }
+        });
+        
+        var operation = new OpenApiOperation
+        {
+            OperationId = "dummy",
+            Responses = new OpenApiResponses
+            {
+                {"200", okResponse}
+            }
+        };
+        
+        var healthcheckPath = new OpenApiPathItem
+        {
+            Description = "Dummy Document Extension",
+            Summary = "Provides an example of extending the OpenApi spec through code"
+        };
+        
+        healthcheckPath.Operations.Add(OperationType.Get, operation);
+        document.OpenApiDocument.Paths["/dummy"] = healthcheckPath;
+        return document;
+    }
+}
+```
+
+This type would then need to be added to the service collection using a custom function startup:
+
+```
+[assembly: FunctionsStartup(typeof(StartUp))]
+public class StartUp : FunctionsStartup
+{
+    public override void Configure(IFunctionsHostBuilder builder)
+    {
+        builder.Services.AddSingleton<IDocumentExtension, DummyDocumentExtension>();
+    }
+}
+```
+
+When the `/swagger.json` endpoint is called, the following JSON would be added to the existing endpoints:
+
+```json
+{
+  "/dummy": {
+    "get": {
+      "operationId": "dummy",
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "Dummy document extension",
+          "schema": {
+            "type": "json"
+          }
+        }
+      }
+    },
+    "x-summary": "Provides an example of extending the OpenApi spec through code",
+    "x-description": "Dummy Document Extension"
+  }
+}
+```
+
+Any `IDocumentExtension` implementations registered will be run before the OpenApi spec is rendered, giving
+developers the opportunity to further manipulate the `IDocument` and make any desired changes.

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/DummyDocumentExtension.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/DummyDocumentExtension.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC
+{
+    public class DummyDocumentExtension : IDocumentExtension
+    {
+        public IDocument ExtendDocument(IDocument document, HttpRequest request)
+        {
+            var okResponse = new OpenApiResponse
+            {
+                Description = "Dummy document extension",
+            };
+
+            okResponse.Content.Add("application/json", new OpenApiMediaType
+            {
+                Schema = new OpenApiSchema
+                {
+                    Type = "json"
+                }
+            });
+
+            var operation = new OpenApiOperation
+            {
+                OperationId = "dummy",
+                Responses = new OpenApiResponses
+                {
+                    {"200", okResponse}
+                }
+            };
+
+            var healthcheckPath = new OpenApiPathItem
+            {
+                Description = "Dummy Document Extension",
+                Summary = "Provides an example of extending the OpenApi spec through code"
+            };
+
+            healthcheckPath.Operations.Add(OperationType.Get, operation);
+            document.OpenApiDocument.Paths["/dummy"] = healthcheckPath;
+
+            return document;
+        }
+    }
+}

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/StartUp.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC/StartUp.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.Services;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC.Configurations;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,6 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.V3IoC
         public override void Configure(IFunctionsHostBuilder builder)
         {
             builder.Services.AddSingleton<AppSettings>();
+            builder.Services.AddSingleton<IDocumentExtension, DummyDocumentExtension>();
             builder.Services.AddTransient<IDummyHttpService, DummyHttpService>();
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IDocumentExtension.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IDocumentExtension.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions
+{
+    /// <summary>
+    /// This provides interfaces to the classes that extend the OpenApi document.
+    /// </summary>
+    public interface IDocumentExtension
+    {
+        IDocument ExtendDocument(IDocument document, HttpRequest request);
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiTriggerFunctionProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiTriggerFunctionProvider.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.Azure.WebJobs.Script.Description;
 
 using Newtonsoft.Json.Linq;
@@ -29,10 +31,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
         /// <summary>
         /// Initializes a new instance of the <see cref="OpenApiTriggerFunctionProvider"/> class.
         /// </summary>
-        public OpenApiTriggerFunctionProvider(OpenApiSettings settings)
+        public OpenApiTriggerFunctionProvider(OpenApiSettings settings, IOpenApiHttpTriggerContext ctx = null, IEnumerable<IDocumentExtension> extensions = null)
         {
             this._settings = settings ?? throw new ArgumentNullException(nameof(settings));
             this._bindings = this.SetupOpenApiHttpBindings();
+
+            context = ctx ?? new OpenApiHttpTriggerContext();
+            registeredExtensions = extensions ?? Enumerable.Empty<IDocumentExtension>();
         }
 
         /// <inheritdoc />

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/Fakes/FakeDocumentExtension.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/Fakes/FakeDocumentExtension.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests.Fakes
+{
+    public class FakeDocumentExtension : IDocumentExtension
+    {
+        public IDocument ExtendDocument(IDocument document, HttpRequest request)
+        {
+            document.OpenApiDocument.Paths["/MockExtension"] = new OpenApiPathItem
+            {
+                Description = "Mock Path",
+            };
+
+            return document;
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/OpenApiDocumentExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/OpenApiDocumentExtensionsTests.cs
@@ -1,0 +1,48 @@
+﻿using System.Reflection;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
+using Newtonsoft.Json.Linq;
+using OpenApiSettings = Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.OpenApiSettings;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests
+{
+    [TestClass]
+    public class OpenApiDocumentExtensionsTests
+    {
+        [TestMethod]
+        public async Task ExtensionTest()
+        {
+            var settings = new Mock<OpenApiSettings>();
+            var ctx = new Mock<OpenApiHttpTriggerContext> { CallBase = true };
+            ctx.Setup(p => p.SetApplicationAssemblyAsync(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(ctx.Object);
+            ctx.Setup(p => p.AuthorizeAsync(It.IsAny<IHttpRequestDataObject>())).ReturnsAsync((OpenApiAuthorizationResult)null);
+            ctx.SetupGet(p => p.OpenApiConfigurationOptions).Returns(new DefaultOpenApiConfigurationOptions());
+            ctx.SetupGet(p => p.ApplicationAssembly).Returns(Assembly.GetExecutingAssembly);
+
+            var provider = new OpenApiTriggerFunctionProvider(settings.Object, ctx.Object, new[] { new FakeDocumentExtension() });
+            var httpContext = new DefaultHttpContext();
+            var executionContext = new ExecutionContext();
+
+            var response = await OpenApiTriggerFunctionProvider.RenderSwaggerDocument(httpContext.Request, "json", executionContext, NullLogger.Instance) as ContentResult;
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(200);
+            response.ContentType.Should().BeEquivalentTo("application/json");
+
+            // Deserialize response
+            var obj = JObject.Parse(response.Content);
+            var mockTrigger = obj.SelectToken("paths./MockExtension");
+            mockTrigger.Should().NotBeNull();
+            mockTrigger.SelectToken("description")?.Value<string>().Should().BeEquivalentTo("Mock Path");
+        }
+    }
+}


### PR DESCRIPTION
We're currently working on a library that adds some custom routes and endpoints using `IFunctionProviders`.  Since a) these functions are not part of the end-facing assembly and b) they're not bound automatically by the Azure Function runtime, they won't show up in the Swagger spec.  For this reason, we would like the ability to *manipulate* the `IDocument` before it's actually rendered out to the browser.

This is an implementation of such a feature and will provide developers with the ability to extend the OpenApi extensions and change or add the `IDocument` in any way they see fit.  This PR includes:

* Implementation of feature
* Unit tests
* Sample code
* Documentation

The changes should be fairly straight forward, and there should be no breaking changes.  There were some changes to the `OpenApiTriggerFunctionProvider` constructor to make it a bit more unit testable, since we needed a way to mock up the `IOpenApiHttpTriggerContext` to call some of the static methods.

Let me know if you have any feedback or have another approach in mind, I'm happy to make any necessary changes.  If we can get such a feature pulled into this library, it'll let us remove a whole bunch of code (basically our own implementation of the `Microsoft.Azure.WebJobs.Extensions.OpenApi` project).