### PR TITLE
remove object schema. when using an object list

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/OpenApiReadonlyData.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/OpenApiReadonlyData.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
+{
+    public static class OpenApiReadonlyData
+    {
+        public static HashSet<string> NonReferentialsTypeString { get; } = new HashSet<string>
+        {
+            "OBJECT",
+            "JTOKEN",
+            "JOBJECT",
+            "JARRAY"
+        };
+
+        public static bool IsNonReferentialsTypeString(string typeName)
+            => NonReferentialsTypeString.Contains(typeName.ToUpperInvariant());
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ListObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ListObjectTypeVisitor.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
                 return;
             }
 
-            foreach (var schema in schemasToBeAdded)
+            foreach (var schema in schemasToBeAdded.Where(p => !OpenApiReadonlyData.IsNonReferentialsTypeString(p.Key)))
             {
                 if (instance.RootSchemas.ContainsKey(schema.Key))
                 {

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
@@ -30,14 +30,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
             typeof(byte[])
         };
 
-        private readonly HashSet<string> _noAddedKeys = new HashSet<string>
-        {
-            "OBJECT",
-            "JTOKEN",
-            "JOBJECT",
-            "JARRAY",
-        };
-
         /// <inheritdoc />
         public ObjectTypeVisitor(VisitorCollection visitorCollection)
             : base(visitorCollection)
@@ -74,10 +66,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
                 isVisitable = false;
             }
             else if (type.HasRecursiveProperty())
-            {
-                isVisitable = false;
-            }
-            else if (type.IsOpenApiException())
             {
                 isVisitable = false;
             }
@@ -215,7 +203,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
                                               .Select(p => p.First())
                                               .ToDictionary(p => p.Value.Title, p => p.Value);
 
-            foreach (var schema in schemasToBeAdded.Where(p => !this._noAddedKeys.Contains(p.Key.ToUpperInvariant())))
+            foreach (var schema in schemasToBeAdded.Where(p => !OpenApiReadonlyData.IsNonReferentialsTypeString(p.Key)))
             {
                 if (instance.RootSchemas.ContainsKey(schema.Key))
                 {

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/RecursiveObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/RecursiveObjectTypeVisitor.cs
@@ -17,14 +17,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
     /// </summary>
     public class RecursiveObjectTypeVisitor : TypeVisitor
     {
-        private readonly HashSet<string> _noAddedKeys = new HashSet<string>
-        {
-            "OBJECT",
-            "JTOKEN",
-            "JOBJECT",
-            "JARRAY",
-        };
-
         /// <inheritdoc />
         public RecursiveObjectTypeVisitor(VisitorCollection visitorCollection)
             : base(visitorCollection)
@@ -217,7 +209,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
                                               .Where(p => p.Value.IsOpenApiSchemaObject())
                                               .ToDictionary(p => p.Value.Title, p => p.Value);
 
-            foreach (var schema in schemasToBeAdded.Where(p => !this._noAddedKeys.Contains(p.Key.ToUpperInvariant())))
+            foreach (var schema in schemasToBeAdded.Where(p => !OpenApiReadonlyData.IsNonReferentialsTypeString(p.Key)))
             {
                 if (instance.RootSchemas.ContainsKey(schema.Key))
                 {


### PR DESCRIPTION
Related Issue : #272 

# What is this about:
- Remove object schema. when using an object list
  - I used the same way as [it](https://github.com/Azure/azure-functions-openapi-extension/pull/234).

- Use a common static class to extract a hash set of key names

# What is include in the PR:
- Modify ObjectTypeVisitor / RecursiveObjectTypeVisitor / ListObjectTypeVisitor
- Declare a new Common Static class (OpenApi Readonly Data) for common code extraction

IMHO, We could use the OpenApiReadonlyData class for other common data sets..