### PR TITLE
Fix/doc mistake on endpoint filtering parameter

### DIFF
--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -159,7 +159,7 @@ http://localhost:7071/api/swagger/ui?tag=admin
 http://localhost:7071/api/swagger.json?tag=admin
 ```
 
-The `tag`  parameter accepts a commma separated list of tags. Any function with any tag passed on the `tag` parameter will be selected.
+The `tag` parameter accepts a commma separated list of tags. Any function with any tag passed on the `tag` parameter will be selected.
 If you only want to show the API endpoints related to `product` or `option` tag, add `tag=product,option` to the querystring:
 
 ```

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -141,20 +141,30 @@ public static async Task<IActionResult> MyFunction2(...)
 {
     ...
 }
-```
 
-If you only want to only show the admin API endpoints, add `filter=admin` to the querystring:
-
-```
-http://localhost:7071/api/swagger/ui?filter=admin
-http://localhost:7071/api/swagger.json?filter=admin
-```
-
-If you want to only show the product related API endpoints, add `filter=product` to the querystring:
+[FunctionName("MyOptionFunction1")]
+[OpenApiOperation(operationId: ..., tags: new[] { "option" })]
+...
+public static async Task<IActionResult> MyOptionFunction1(...)
+{
+    ...
+}
 
 ```
-http://localhost:7071/api/swagger/ui?filter=product
-http://localhost:7071/api/swagger.json?filter=product
+
+If you only want to only show the admin API endpoints, add `tag=admin` to the querystring:
+
+```
+http://localhost:7071/api/swagger/ui?tag=admin
+http://localhost:7071/api/swagger.json?tag=admin
+```
+
+The `tag`  parameter accepts a commma separated list of tags. Any function with any tag passed on the `tag` parameter will be selected.
+If you only want to show the API endpoints related to `product` or `option` tag, add `tag=product,option` to the querystring:
+
+```
+http://localhost:7071/api/swagger/ui?tag=product,option
+http://localhost:7071/api/swagger.json?tag=product,option
 ```
 
 


### PR DESCRIPTION
In Microsoft.Azure.WebJobs.Extensions.OpenApi, the Document::Build() method [use a `tag` parameter](https://github.com/Azure/azure-functions-openapi-extension/blob/main/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/Document.cs#L137) to read the filter but the doc talk about a `filter` parameter.
I fixed the doc and also modified a sample that was redondant to document the case of a filter based on a list of tags.