### PR TITLE
Add a HideDocument flag akin to HideSwaggerUI

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/Configurations/OpenApiSettings.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/Configurations/OpenApiSettings.cs
@@ -11,6 +11,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations
         public virtual bool HideSwaggerUI { get; set; }
 
         /// <summary>
+        /// Gets or sets the value indicating whether to hide the document pages or not.
+        /// </summary>
+        public virtual bool HideDocument { get; set; }
+
+        /// <summary>
         /// Gets or sets the API key to access to OpenAPI document.
         /// </summary>
         public virtual string ApiKey { get; set; }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiTriggerFunctionProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiTriggerFunctionProvider.cs
@@ -48,33 +48,37 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
 
         private Dictionary<string, HttpBindingMetadata> SetupOpenApiHttpBindings()
         {
-            var renderSwaggerDocument = new HttpBindingMetadata()
-            {
-                Methods = new List<string>() { HttpMethods.Get },
-                Route = "swagger.{extension}",
-                AuthLevel = this._settings.AuthLevel?.Document ?? AuthorizationLevel.Anonymous,
-            };
+            var bindings = new Dictionary<string, HttpBindingMetadata>();
 
-            var renderOpenApiDocument = new HttpBindingMetadata()
+            if (!this._settings.HideDocument)
             {
-                Methods = new List<string>() { HttpMethods.Get },
-                Route = "openapi/{version}.{extension}",
-                AuthLevel = this._settings.AuthLevel?.Document ?? AuthorizationLevel.Anonymous,
-            };
+                var renderSwaggerDocument = new HttpBindingMetadata()
+                {
+                    Methods = new List<string>() { HttpMethods.Get },
+                    Route = "swagger.{extension}",
+                    AuthLevel = this._settings.AuthLevel?.Document ?? AuthorizationLevel.Anonymous,
+                };
 
-            var renderOAuth2Redirect = new HttpBindingMetadata()
-            {
-                Methods = new List<string>() { HttpMethods.Get },
-                Route = "oauth2-redirect.html",
-                AuthLevel = this._settings.AuthLevel?.UI ?? AuthorizationLevel.Anonymous,
-            };
+                bindings.Add(RenderSwaggerDocumentKey, renderSwaggerDocument);
 
-            var bindings = new Dictionary<string, HttpBindingMetadata>()
-            {
-                { RenderSwaggerDocumentKey, renderSwaggerDocument },
-                { RenderOpenApiDocumentKey, renderOpenApiDocument },
-                { RenderOAuth2RedirectKey, renderOAuth2Redirect },
-            };
+                var renderOpenApiDocument = new HttpBindingMetadata()
+                {
+                    Methods = new List<string>() { HttpMethods.Get },
+                    Route = "openapi/{version}.{extension}",
+                    AuthLevel = this._settings.AuthLevel?.Document ?? AuthorizationLevel.Anonymous,
+                };
+
+                bindings.Add(RenderSwaggerDocumentKey, renderOpenApiDocument);
+
+                var renderOAuth2Redirect = new HttpBindingMetadata()
+                {
+                    Methods = new List<string>() { HttpMethods.Get },
+                    Route = "oauth2-redirect.html",
+                    AuthLevel = this._settings.AuthLevel?.UI ?? AuthorizationLevel.Anonymous,
+                };
+
+                bindings.Add(RenderSwaggerDocumentKey, renderOAuth2Redirect);
+            }
 
             if (!this._settings.HideSwaggerUI)
             {
@@ -93,11 +97,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
 
         private List<FunctionMetadata> GetFunctionMetadataList()
         {
-            var list = new List<FunctionMetadata>()
+            var list = new List<FunctionMetadata>();
+
+            if (!this._settings.HideDocument)
             {
-                this.GetFunctionMetadata(RenderSwaggerDocumentKey),
-                this.GetFunctionMetadata(RenderOpenApiDocumentKey),
-                this.GetFunctionMetadata(RenderOAuth2RedirectKey),
+                list.AddRange(new[]
+                {
+                    this.GetFunctionMetadata(RenderSwaggerDocumentKey),
+                    this.GetFunctionMetadata(RenderOpenApiDocumentKey),
+                    this.GetFunctionMetadata(RenderOAuth2RedirectKey)
+                });
             };
 
             if (!this._settings.HideSwaggerUI)

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiTriggerFunctionProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiTriggerFunctionProvider.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
                     AuthLevel = this._settings.AuthLevel?.Document ?? AuthorizationLevel.Anonymous,
                 };
 
-                bindings.Add(RenderSwaggerDocumentKey, renderOpenApiDocument);
+                bindings.Add(RenderOpenApiDocumentKey, renderOpenApiDocument);
 
                 var renderOAuth2Redirect = new HttpBindingMetadata()
                 {
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
                     AuthLevel = this._settings.AuthLevel?.UI ?? AuthorizationLevel.Anonymous,
                 };
 
-                bindings.Add(RenderSwaggerDocumentKey, renderOAuth2Redirect);
+                bindings.Add(RenderOAuth2RedirectKey, renderOAuth2Redirect);
             }
 
             if (!this._settings.HideSwaggerUI)

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiTriggerFunctionProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiTriggerFunctionProvider.cs
@@ -70,26 +70,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
 
                 bindings.Add(RenderOpenApiDocumentKey, renderOpenApiDocument);
 
-                var renderOAuth2Redirect = new HttpBindingMetadata()
+                if (!this._settings.HideSwaggerUI)
                 {
-                    Methods = new List<string>() { HttpMethods.Get },
-                    Route = "oauth2-redirect.html",
-                    AuthLevel = this._settings.AuthLevel?.UI ?? AuthorizationLevel.Anonymous,
-                };
+                    var renderOAuth2Redirect = new HttpBindingMetadata()
+                    {
+                        Methods = new List<string>() { HttpMethods.Get },
+                        Route = "oauth2-redirect.html",
+                        AuthLevel = this._settings.AuthLevel?.UI ?? AuthorizationLevel.Anonymous,
+                    };
 
-                bindings.Add(RenderOAuth2RedirectKey, renderOAuth2Redirect);
-            }
+                    bindings.Add(RenderOAuth2RedirectKey, renderOAuth2Redirect);
 
-            if (!this._settings.HideSwaggerUI)
-            {
-                var renderSwaggerUI = new HttpBindingMetadata()
-                {
-                    Methods = new List<string>() { HttpMethods.Get },
-                    Route = "swagger/ui",
-                    AuthLevel = this._settings.AuthLevel?.UI ?? AuthorizationLevel.Anonymous,
-                };
+                    var renderSwaggerUI = new HttpBindingMetadata()
+                    {
+                        Methods = new List<string>() { HttpMethods.Get },
+                        Route = "swagger/ui",
+                        AuthLevel = this._settings.AuthLevel?.UI ?? AuthorizationLevel.Anonymous,
+                    };
 
-                bindings.Add(RenderSwaggerUIKey, renderSwaggerUI);
+                    bindings.Add(RenderSwaggerUIKey, renderSwaggerUI);
+                }
             }
 
             return bindings;
@@ -104,15 +104,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
                 list.AddRange(new[]
                 {
                     this.GetFunctionMetadata(RenderSwaggerDocumentKey),
-                    this.GetFunctionMetadata(RenderOpenApiDocumentKey),
-                    this.GetFunctionMetadata(RenderOAuth2RedirectKey)
+                    this.GetFunctionMetadata(RenderOpenApiDocumentKey)
                 });
-            };
 
-            if (!this._settings.HideSwaggerUI)
-            {
-                list.Add(this.GetFunctionMetadata(RenderSwaggerUIKey));
-            }
+                if (!this._settings.HideSwaggerUI)
+                {
+                    list.AddRange(new[]
+                    {
+                        this.GetFunctionMetadata(RenderSwaggerUIKey),
+                        this.GetFunctionMetadata(RenderOAuth2RedirectKey)
+                    });
+                }
+            };
 
             return list;
         }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/Configurations/OpenApiSettingsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/Configurations/OpenApiSettingsTests.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests.Configurations
     public class OpenApiSettingsTests
     {
         [DataTestMethod]
-        [DataRow("true", "false", true, false, "lorem", "Function", AuthorizationLevel.Function, "Anonymous", AuthorizationLevel.Anonymous, "http://localhost:7071", "https://contoso.com/api/")]
-        [DataRow("false", "false", false, false, "ipsum", "Anonymous", AuthorizationLevel.Anonymous, "Function", AuthorizationLevel.Function, "http://contoso", "https://fabrikam.com/api/")]
-        [DataRow("false", "true", false, true, "ipsum", "Anonymous", AuthorizationLevel.Anonymous, "Function", AuthorizationLevel.Function, "http://contoso", "https://fabrikam.com/api/")]
+        [DataRow("true", true, "false", false, "lorem", "Function", AuthorizationLevel.Function, "Anonymous", AuthorizationLevel.Anonymous, "http://localhost:7071", "https://contoso.com/api/")]
+        [DataRow("false", false, "false", false, "ipsum", "Anonymous", AuthorizationLevel.Anonymous, "Function", AuthorizationLevel.Function, "http://contoso", "https://fabrikam.com/api/")]
+        [DataRow("false", false, "true", true, "ipsum", "Anonymous", AuthorizationLevel.Anonymous, "Function", AuthorizationLevel.Function, "http://contoso", "https://fabrikam.com/api/")]
         public void Given_EnvironmentVariables_When_Instantiated_Then_It_Should_Return_Result(string hideSwaggerUI, bool expectedHideSwaggerUI,
                                                                                               string hideDocument, bool expectedHideDocument,
                                                                                               string apiKey,

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/Configurations/OpenApiSettingsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/Configurations/OpenApiSettingsTests.cs
@@ -15,14 +15,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests.Configurations
     public class OpenApiSettingsTests
     {
         [DataTestMethod]
-        [DataRow("true", true, "lorem", "Function", AuthorizationLevel.Function, "Anonymous", AuthorizationLevel.Anonymous, "http://localhost:7071", "https://contoso.com/api/")]
-        [DataRow("false", false, "ipsum", "Anonymous", AuthorizationLevel.Anonymous, "Function", AuthorizationLevel.Function, "http://contoso", "https://fabrikam.com/api/")]
-        public void Given_EnvironmentVariables_When_Instantiated_Then_It_Should_Return_Result(string hideSwaggerUI, bool expectedHideSwaggerUI, string apiKey,
+        [DataRow("true", "false", true, false, "lorem", "Function", AuthorizationLevel.Function, "Anonymous", AuthorizationLevel.Anonymous, "http://localhost:7071", "https://contoso.com/api/")]
+        [DataRow("false", "false", false, false, "ipsum", "Anonymous", AuthorizationLevel.Anonymous, "Function", AuthorizationLevel.Function, "http://contoso", "https://fabrikam.com/api/")]
+        [DataRow("false", "true", false, true, "ipsum", "Anonymous", AuthorizationLevel.Anonymous, "Function", AuthorizationLevel.Function, "http://contoso", "https://fabrikam.com/api/")]
+        public void Given_EnvironmentVariables_When_Instantiated_Then_It_Should_Return_Result(string hideSwaggerUI, bool expectedHideSwaggerUI,
+                                                                                              string hideDocument, bool expectedHideDocument,
+                                                                                              string apiKey,
                                                                                               string authLevelDoc, AuthorizationLevel expectedAuthLevelDoc,
                                                                                               string authLevelUI, AuthorizationLevel expectedAuthLevelUI,
                                                                                               string proxyUrl, string hostnames)
         {
             Environment.SetEnvironmentVariable("OpenApi__HideSwaggerUI", hideSwaggerUI);
+            Environment.SetEnvironmentVariable("OpenApi__HideDocument", hideDocument);
             Environment.SetEnvironmentVariable("OpenApi__ApiKey", apiKey);
             Environment.SetEnvironmentVariable("OpenApi__AuthLevel__Document", authLevelDoc);
             Environment.SetEnvironmentVariable("OpenApi__AuthLevel__UI", authLevelUI);
@@ -33,6 +37,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests.Configurations
             var settings = config.Get<OpenApiSettings>("OpenApi");
 
             settings.HideSwaggerUI.Should().Be(expectedHideSwaggerUI);
+            settings.HideDocument.Should().Be(expectedHideDocument);
             settings.ApiKey.Should().Be(apiKey);
             settings.AuthLevel.Document.Should().Be(expectedAuthLevelDoc);
             settings.AuthLevel.UI.Should().Be(expectedAuthLevelUI);

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/OpenApiTriggerFunctionProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/OpenApiTriggerFunctionProviderTests.cs
@@ -39,6 +39,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests
         }
 
         [DataTestMethod]
+        [DataRow(true, 1)]
+        [DataRow(false, 4)]
+        public async Task Given_HideDocument_When_GetFunctionMetadataAsync_Invoked_Then_It_Should_Return_Result(bool hideDocument, int expected)
+        {
+            var settings = new Mock<OpenApiSettings>();
+            settings.SetupGet(p => p.HideDocument).Returns(hideDocument);
+
+            var provider = new OpenApiTriggerFunctionProvider(settings.Object);
+
+            var result = await provider.GetFunctionMetadataAsync().ConfigureAwait(false);
+
+            result.Should().HaveCount(expected);
+        }
+
+        [DataTestMethod]
         [DataRow(AuthorizationLevel.Anonymous, AuthorizationLevel.Anonymous)]
         [DataRow(AuthorizationLevel.Anonymous, AuthorizationLevel.Function)]
         [DataRow(AuthorizationLevel.Function, AuthorizationLevel.Anonymous)]
@@ -51,6 +66,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests
 
             var settings = new Mock<OpenApiSettings>();
             settings.SetupGet(p => p.HideSwaggerUI).Returns(false);
+            settings.SetupGet(p => p.HideDocument).Returns(false);
             settings.SetupGet(p => p.AuthLevel).Returns(authLevelSettings.Object);
 
             var provider = new OpenApiTriggerFunctionProvider(settings.Object);

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/OpenApiTriggerFunctionProviderTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/OpenApiTriggerFunctionProviderTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests
         }
 
         [DataTestMethod]
-        [DataRow(true, 3)]
+        [DataRow(true, 2)]
         [DataRow(false, 4)]
         public async Task Given_HideSwaggerUI_When_GetFunctionMetadataAsync_Invoked_Then_It_Should_Return_Result(bool hideSwaggerUI, int expected)
         {
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests
         }
 
         [DataTestMethod]
-        [DataRow(true, 1)]
+        [DataRow(true, 0)]
         [DataRow(false, 4)]
         public async Task Given_HideDocument_When_GetFunctionMetadataAsync_Invoked_Then_It_Should_Return_Result(bool hideDocument, int expected)
         {


### PR DESCRIPTION
Added a flag to hide the document bindings so that the feature can be "turned off" in a particular configuration of a deployed API.

Setting HideDocument will also hide the UI.
