### PR TITLE
Fix object schema rendering issue

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
@@ -139,8 +139,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
                                 .Select(p => p.IsOpenApiArray() || p.IsOpenApiDictionary() ? p.GetOpenApiSubType() : p)
                                 .Distinct()
                                 .Where(p => !p.IsSimpleType())
-                                .Where(p => p != typeof(JObject))
-                                .Where(p => p != typeof(JToken))
+                                .Where(p => p.IsReferentialType())
                                 .Where(p => !typeof(Array).IsAssignableFrom(p))
                                 .ToList();
 
@@ -155,6 +154,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
 
             var union = schemas.Concat(rootSchemas.Where(p => !schemas.Keys.Contains(p.Key)))
                                .Distinct()
+                               .Where(p => p.Key.ToUpperInvariant() != "OBJECT")
                                .OrderBy(p => p.Key)
                                .ToDictionary(p => p.Key,
                                              p =>

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/DictionaryObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/DictionaryObjectTypeVisitor.cs
@@ -72,6 +72,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
 
             var properties = subAcceptor.Schemas.First().Value;
 
+            // Forces to remove the title value from the additionalProperties attribute.
+            properties.Title = null;
+
             // Adds the reference to the schema for the underlying type.
             if (this.IsReferential(underlyingType))
             {

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ListObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ListObjectTypeVisitor.cs
@@ -73,6 +73,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
 
             var items = subAcceptor.Schemas.First().Value;
 
+            // Forces to remove the title value from the items attribute.
+            items.Title = null;
+
             // Adds the reference to the schema for the underlying type.
             if (this.IsReferential(underlyingType))
             {

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_ApplicationJson_BaseObject_Tests.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_ApplicationJson_BaseObject_Tests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -55,32 +56,64 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
         }
 
         [DataTestMethod]
-        [DataRow("baseObjectModel", "baseObjectValue", true)]
-        [DataRow("baseObjectModel", "nonObjectValue", false)]
-        [DataRow("baseObjectModel", "subObjectValue", false)]
-        [DataRow("baseSubObjectModel", "baseSubObjectValue", true)]
-        public void Given_OpenApiDocument_And_BaseObject_Then_It_Should_Return_Expected_Type(string @ref, string propName, bool isBaseObject)
+        [DataRow("baseObjectModel", "baseObjectValue")]
+        [DataRow("baseSubObjectModel", "baseSubObjectValue")]
+        public void Given_OpenApiDocument_And_BaseObject_Then_It_Should_Return_Expected_TypeOf_Object(string @ref, string propName)
         {
             var schemas = this._doc["components"]["schemas"];
 
             var type = schemas?[@ref]?["properties"]?[propName]?["type"]?.Value<string>() ;
 
-            if (isBaseObject)
-            {
-                type.Should().Be("object");
-            }
-            else
-            {
-                type.Should().NotBe("object");
-            }
+            type.Should().Be("object");
         }
 
-        // [TestMethod]
-        // public void Given_OpenApiDocument_Then_It_Should_Return_Null()
-        // {
-        //     var @object = this._doc["components"]["schemas"]["object"];
+        [DataTestMethod]
+        [DataRow("baseObjectModel", "nonObjectValue")]
+        [DataRow("baseObjectModel", "subObjectValue")]
+        public void Given_OpenApiDocument_And_BaseObject_Then_It_Should_Not_Return_Expected_TypeOf_Object(string @ref, string propName)
+        {
+            var schemas = this._doc["components"]["schemas"];
 
-        //     @object.Should().BeNull();
-        // }
+            var type = schemas?[@ref]?["properties"]?[propName]?["type"]?.Value<string>() ;
+
+            type.Should().NotBe("object");
+        }
+
+        [DataTestMethod]
+        [DataRow("baseObjectModel", "baseObjectList", "array")]
+        [DataRow("baseObjectModel", "baseObjectDictionary", "object")]
+        public void Given_OpenApiDocument_And_BaseObject_Then_It_Should_Return_Expected_Type(string @ref, string propName, string listType)
+        {
+            var schemas = this._doc["components"]["schemas"];
+
+            var type = schemas?[@ref]?["properties"]?[propName]?["type"]?.Value<string>();
+
+            type.Should().Be(listType);
+        }
+
+        [DataTestMethod]
+        [DataRow("baseObjectModel", "baseObjectList", "items", "object")]
+        [DataRow("baseObjectModel", "baseObjectDictionary", "additionalProperties", "object")]
+        public void Given_OpenApiDocument_And_BaseObject_Then_It_Should_Return_Expected_SubType(string @ref, string propName, string attrName, string subType)
+        {
+            var schemas = this._doc["components"]["schemas"];
+
+            var property = schemas?[@ref]?["properties"]?[propName];
+            var attr = property[attrName];
+
+            attr["type"].Value<string>().Should().Be(subType);
+        }
+
+        [DataTestMethod]
+        [DataRow("baseObjectModel", "baseObjectList", "items")]
+        [DataRow("baseObjectModel", "baseObjectDictionary", "additionalProperties")]
+        public void Given_OpenApiDocument_And_BaseObject_Then_It_Should_Return_Null_Title(string @ref, string propName, string attr)
+        {
+            var schemas = this._doc["components"]["schemas"];
+
+            var title = schemas?[@ref]?["properties"]?[propName]?[attr]?["title"]?.Value<string>();
+
+            title.Should().BeNull();
+        }
     }
 }

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Models/BaseObjectModel.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Models/BaseObjectModel.cs
@@ -1,8 +1,10 @@
+using System.Collections.Generic;
+
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Models
 {
     public class BaseSubObjectModel
     {
-        public object BaseSubObjectValue{ get; set; }
+        public object BaseSubObjectValue { get; set; }
     }
 
     public class BaseObjectModel
@@ -10,5 +12,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Models
         public object BaseObjectValue { get; set; }
         public int NonObjectValue { get; set; }
         public BaseSubObjectModel SubObjectValue { get; set; }
+        public List<object> BaseObjectList { get; set; }
+        public Dictionary<string, object> BaseObjectDictionary { get; set; }
     }
 }


### PR DESCRIPTION
Related to: #272 

This PR is to remove:

* Unnecessary object types like `object` or `uri` from the root schema definition
* Unnecessary title value from both array and dictionary object type definitions

