### PR TITLE
Fix: OpenAPI attributes are not getting picked up if they are in a referenced class library project #298

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Extensions/DocumentHelperExtensions.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Extensions/DocumentHelperExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Extensions
         /// <returns>List of <see cref="MethodInfo"/> instances representing HTTP triggers.</returns>
         public static List<MethodInfo> GetHttpTriggerMethods(this IDocumentHelper helper, Assembly assembly, IEnumerable<string> tags = null)
         {
-            var methods = assembly.GetLoadableTypes()
+            var methods = assembly.GetLoadableTypes(includeReferenced: true)
                                   .SelectMany(p => p.GetMethods())
                                   .Where(p => p.ExistsCustomAttribute<FunctionAttribute>())
                                   .Where(p => p.ExistsCustomAttribute<OpenApiOperationAttribute>())

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Extensions/DocumentHelperExtensions.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Extensions/DocumentHelperExtensions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Extensions
         /// <returns>List of <see cref="MethodInfo"/> instances representing HTTP triggers.</returns>
         public static List<MethodInfo> GetHttpTriggerMethods(this IDocumentHelper helper, Assembly assembly, IEnumerable<string> tags = null)
         {
-            var methods = assembly.GetLoadableTypes(includeReferenced: true)
+            var methods = assembly.GetLoadableTypes()
                                   .SelectMany(p => p.GetMethods())
                                   .Where(p => p.ExistsCustomAttribute<FunctionAttribute>())
                                   .Where(p => p.ExistsCustomAttribute<OpenApiOperationAttribute>())

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/AssemblyExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/AssemblyExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reflection;
 
@@ -13,12 +13,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
         /// Loads the <see cref="Assembly"/>'s <see cref="Type"/>s that can be loaded ignoring others.
         /// </summary>
         /// <param name="assembly"><see cref="Assembly"/> instance.</param>
+        /// <param name="includeReferenced">Set to true to load <see cref="Type"/>s from referenced assemblies too</param>
         /// <returns>Returns the list of <see cref="Type"/>s that can be loaded.</returns>
-        public static Type[] GetLoadableTypes(this Assembly assembly)
+        public static Type[] GetLoadableTypes(this Assembly assembly, bool includeReferenced = false)
         {
             try
             {
-                return assembly.GetTypes();
+                return includeReferenced
+                    ? assembly.GetTypes()
+                        .Union(assembly
+                            .GetReferencedAssemblies()
+                            .SelectMany(x => Assembly.Load(x).GetTypes()))
+                        .Distinct()
+                        .ToArray()
+                    : assembly.GetTypes();
             }
             catch (ReflectionTypeLoadException exception)
             {

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/AssemblyExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/AssemblyExtensions.cs
@@ -21,7 +21,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
                 return assembly.GetTypes()
                     .Union(assembly
                         .GetReferencedAssemblies()
-                        .Where(x => !x.FullName.StartsWith("Microsoft.Azure.WebJobs.Extensions.OpenApi"))
+                        .Where(x =>
+                            !x.FullName.StartsWith("Microsoft.Azure.WebJobs.Extensions.OpenApi") &&
+                            !x.FullName.StartsWith("Microsoft.Azure.Functions.Worker.Extensions.OpenApi"))
                         .SelectMany(x => Assembly.Load(x).GetTypes()))
                     .Distinct()
                     .ToArray();

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/AssemblyExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/AssemblyExtensions.cs
@@ -10,23 +10,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
     public static class AssemblyExtensions
     {
         /// <summary>
-        /// Loads the <see cref="Assembly"/>'s <see cref="Type"/>s that can be loaded ignoring others.
+        /// Loads the <see cref="Assembly"/>'s <see cref="Type"/>s that can be loaded ignoring others (includes referenced assemblies).
         /// </summary>
         /// <param name="assembly"><see cref="Assembly"/> instance.</param>
-        /// <param name="includeReferenced">Set to true to load <see cref="Type"/>s from referenced assemblies too</param>
         /// <returns>Returns the list of <see cref="Type"/>s that can be loaded.</returns>
-        public static Type[] GetLoadableTypes(this Assembly assembly, bool includeReferenced = false)
+        public static Type[] GetLoadableTypes(this Assembly assembly)
         {
             try
             {
-                return includeReferenced
-                    ? assembly.GetTypes()
-                        .Union(assembly
-                            .GetReferencedAssemblies()
-                            .SelectMany(x => Assembly.Load(x).GetTypes()))
-                        .Distinct()
-                        .ToArray()
-                    : assembly.GetTypes();
+                return assembly.GetTypes()
+                    .Union(assembly
+                        .GetReferencedAssemblies()
+                        .Where(x => !x.FullName.StartsWith("Microsoft.Azure.WebJobs.Extensions.OpenApi"))
+                        .SelectMany(x => Assembly.Load(x).GetTypes()))
+                    .Distinct()
+                    .ToArray();
             }
             catch (ReflectionTypeLoadException exception)
             {

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/VisitorCollection.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/VisitorCollection.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
             var collection = new VisitorCollection();
             collection.Visitors = typeof(IVisitor).Assembly
                                            .GetLoadableTypes()
-                                           .Where(p => p.GetInterface(nameof(IVisitor)) != null && p.IsClass && !p.IsAbstract)
+                                           .Where(p => p.HasInterface<IVisitor>() && p.IsClass && !p.IsAbstract)
                                            .Select(p => (IVisitor)Activator.CreateInstance(p, collection)).ToList(); // NOTE: there is no direct enforcement on the constructor arguments of the visitors
             return collection;
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/VisitorCollection.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/VisitorCollection.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
             var collection = new VisitorCollection();
             collection.Visitors = typeof(IVisitor).Assembly
                                            .GetLoadableTypes()
-                                           .Where(p => p.Name.EndsWith("Visitor") && p.IsClass && !p.IsAbstract)
+                                           .Where(p => p.GetInterface(nameof(IVisitor)) != null && p.IsClass && !p.IsAbstract)
                                            .Select(p => (IVisitor)Activator.CreateInstance(p, collection)).ToList(); // NOTE: there is no direct enforcement on the constructor arguments of the visitors
             return collection;
         }


### PR DESCRIPTION
This solution introduces an optional parameter to load referenced assemblies' types as well when trying to find out which methods are eligible to be shown on the SwaggerUI