### PR TITLE
Fix the API prefix overly trimmed

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/SwaggerUI.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/SwaggerUI.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
             {
                 this._baseUrl = baseUrl;
 
-                absolutePath = new Uri(this._baseUrl).AbsolutePath.Trim('/');
+                absolutePath = new Uri(this._baseUrl).AbsolutePath.TrimEnd('/');
                 this._swaggerUiApiPrefix = absolutePath;
 
                 return this;
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
 
             this._baseUrl = servers.First().Url;
 
-            absolutePath = new Uri(this._baseUrl).AbsolutePath.Trim('/');
+            absolutePath = new Uri(this._baseUrl).AbsolutePath.TrimEnd('/');
             this._swaggerUiApiPrefix = absolutePath;
 
             return this;

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/SwaggerUITests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/SwaggerUITests.cs
@@ -117,10 +117,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
         }
 
         [DataTestMethod]
-        [DataRow("http", "localhost", "api", "api")]
-        [DataRow("https", "localhost", "api/", "api")]
-        [DataRow("http", "localhost", "api/prod", "api/prod")]
-        [DataRow("https", "localhost", "api/prod/", "api/prod")]
+        [DataRow("http", "localhost", "api", "/api")]
+        [DataRow("https", "localhost", "api/", "/api")]
+        [DataRow("http", "localhost", "api/prod", "/api/prod")]
+        [DataRow("https", "localhost", "api/prod/", "/api/prod")]
         public void Given_NullOptions_When_AddServer_Invoked_Then_It_Should_Return_SwaggerUIApiPrefix(string scheme, string host, string routePrefix, string expected)
         {
             var req = new Mock<IHttpRequestDataObject>();


### PR DESCRIPTION
Related to #307 

This PR is to fix the API prefix that has been overly trimmed the beginning slash.
