### PR TITLE
Resolve TypeLoadException for QueryCollection (#296)

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Extensions/OpenApiHttpRequestDataExtensions.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Extensions/OpenApiHttpRequestDataExtensions.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
@@ -63,7 +62,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Extensions
             {
                 queries = new Dictionary<string, StringValues>();
             }
-
+            
             return new QueryCollection(queries);
         }
 

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.csproj
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\builds\worker.props" />
 
@@ -30,6 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Azure.Core.NewtonsoftJson" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.12" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.1.0" />


### PR DESCRIPTION
Related to #296 

**Changes proposed in this pull request**:

* Add **FrameworkReference** for *Microsoft.AspNetCore.App* to *Microsoft.Azure.Functions.Worker.Extensions.OpenApi.csproj*
* Replace type reference for **QueryCollection** from _Microsoft.AspNetCore.Http.Internal.QueryCollection_ (which is not present in AspNetCore-referencing projects and is internal) to framework-provided _Microsoft.AspNetCore.Http.QueryCollection_