### PR TITLE
Add Dictionary test codes and modify Dictionaryobject route

### DIFF
--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_ApplicationJson_DictionaryObject_Tests.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_ApplicationJson_DictionaryObject_Tests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
         }
 
         [DataTestMethod]
-        [DataRow("/get-applicationjson-dictionary", "get", "200")]
+        [DataRow("/get-applicationjson-dictionaryobject", "get", "200")]
         public void Given_OpenApiDocument_Then_It_Should_Return_OperationResponse(string path, string operationType, string responseCode)
         {
             var responses = this._doc["paths"][path][operationType]["responses"];
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
         }
 
         [DataTestMethod]
-        [DataRow("/get-applicationjson-dictionary", "get", "200", "application/json")]
+        [DataRow("/get-applicationjson-dictionaryobject", "get", "200", "application/json")]
         public void Given_OpenApiDocument_Then_It_Should_Return_OperationResponseContentType(string path, string operationType, string responseCode, string contentType)
         {
             var content = this._doc["paths"][path][operationType]["responses"][responseCode]["content"];
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
         }
 
         [DataTestMethod]
-        [DataRow("/get-applicationjson-dictionary", "get", "200", "application/json", "dictionaryObjectModel")]
+        [DataRow("/get-applicationjson-dictionaryobject", "get", "200", "application/json", "dictionaryObjectModel")]
         public void Given_OpenApiDocument_Then_It_Should_Return_OperationResponseContentTypeSchema(string path, string operationType, string responseCode, string contentType, string reference)
         {
             var content = this._doc["paths"][path][operationType]["responses"][responseCode]["content"];

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_ApplicationJson_Dictionary_Tests.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_ApplicationJson_Dictionary_Tests.cs
@@ -83,9 +83,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
         public void Given_OpenApiDocument_Then_It_Should_Return_OperationResponseContentTypeSchemaType(string path, string operationType, string responseCode, string contentType, string itemType)
         {
             var content = this._doc["paths"][path][operationType]["responses"][responseCode]["content"];
-
             var schema = content[contentType]["schema"];
+
             var type = schema["type"];
+
             type.Value<string>().Should().Be(itemType);
         }
 
@@ -97,9 +98,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
         public void Given_OpenApiDocument_Then_It_Should_Return_OperationResponseContentTypeSchemaPropertiesType(string path, string operationType, string responseCode, string contentType, string dataType, string itemType)
         {
             var content = this._doc["paths"][path][operationType]["responses"][responseCode]["content"];
-
             var schema = content[contentType]["schema"];
-            var additionaltype =schema["additionalProperties"]["type"];
+
+            var additionaltype = schema["additionalProperties"]["type"];
+
             additionaltype.Value<string>().Should().Be(itemType);
         }
 

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_ApplicationJson_Dictionary_Tests.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_ApplicationJson_Dictionary_Tests.cs
@@ -29,9 +29,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
 
         [DataTestMethod]
         [DataRow("/get-applicationjson-dictionary")]
-        [DataRow("/get-applicationjson-dictionary-i")]
-        [DataRow("/get-applicationjson-dictionary-ireadonly")]
-        [DataRow("/get-applicationjson-dictionary-key")]
+        [DataRow("/get-applicationjson-dictionary-idictionary")]
+        [DataRow("/get-applicationjson-dictionary-ireadonlydictionary")]
+        [DataRow("/get-applicationjson-dictionary-keyvaluepair")]
         public void Given_OpenApiDocument_Then_It_Should_Return_Path(string path)
         {
             var paths = this._doc["paths"];
@@ -41,9 +41,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
 
         [DataTestMethod]
         [DataRow("/get-applicationjson-dictionary", "get")]
-        [DataRow("/get-applicationjson-dictionary-i", "get")]
-        [DataRow("/get-applicationjson-dictionary-ireadonly", "get")]
-        [DataRow("/get-applicationjson-dictionary-key", "get")]
+        [DataRow("/get-applicationjson-dictionary-idictionary", "get")]
+        [DataRow("/get-applicationjson-dictionary-ireadonlydictionary", "get")]
+        [DataRow("/get-applicationjson-dictionary-keyvaluepair", "get")]
         public void Given_OpenApiDocument_Then_It_Should_Return_OperationType(string path, string operationType)
         {
             var pathItem = this._doc["paths"][path];
@@ -53,9 +53,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
 
         [DataTestMethod]
         [DataRow("/get-applicationjson-dictionary", "get", "200")]
-        [DataRow("/get-applicationjson-dictionary-i", "get", "200")]
-        [DataRow("/get-applicationjson-dictionary-ireadonly", "get", "200")]
-        [DataRow("/get-applicationjson-dictionary-key", "get", "200")]
+        [DataRow("/get-applicationjson-dictionary-idictionary", "get", "200")]
+        [DataRow("/get-applicationjson-dictionary-ireadonlydictionary", "get", "200")]
+        [DataRow("/get-applicationjson-dictionary-keyvaluepair", "get", "200")]
         public void Given_OpenApiDocument_Then_It_Should_Return_OperationResponse(string path, string operationType, string responseCode)
         {
             var responses = this._doc["paths"][path][operationType]["responses"];
@@ -65,9 +65,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
 
         [DataTestMethod]
         [DataRow("/get-applicationjson-dictionary", "get", "200", "application/json")]
-        [DataRow("/get-applicationjson-dictionary-i", "get", "200", "application/json")]
-        [DataRow("/get-applicationjson-dictionary-ireadonly", "get", "200", "application/json")]
-        [DataRow("/get-applicationjson-dictionary-key", "get", "200", "application/json")]
+        [DataRow("/get-applicationjson-dictionary-idictionary", "get", "200", "application/json")]
+        [DataRow("/get-applicationjson-dictionary-ireadonlydictionary", "get", "200", "application/json")]
+        [DataRow("/get-applicationjson-dictionary-keyvaluepair", "get", "200", "application/json")]
         public void Given_OpenApiDocument_Then_It_Should_Return_OperationResponseContentType(string path, string operationType, string responseCode, string contentType)
         {
             var content = this._doc["paths"][path][operationType]["responses"][responseCode]["content"];
@@ -77,9 +77,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
 
         [DataTestMethod]
         [DataRow("/get-applicationjson-dictionary", "get", "200", "application/json", "object")]
-        [DataRow("/get-applicationjson-dictionary-i", "get", "200", "application/json","object")]
-        [DataRow("/get-applicationjson-dictionary-ireadonly", "get", "200", "application/json",  "object")]
-        [DataRow("/get-applicationjson-dictionary-key", "get", "200", "application/json", "object")]
+        [DataRow("/get-applicationjson-dictionary-idictionary", "get", "200", "application/json","object")]
+        [DataRow("/get-applicationjson-dictionary-ireadonlydictionary", "get", "200", "application/json",  "object")]
+        [DataRow("/get-applicationjson-dictionary-keyvaluepair", "get", "200", "application/json", "object")]
         public void Given_OpenApiDocument_Then_It_Should_Return_OperationResponseContentTypeSchemaType(string path, string operationType, string responseCode, string contentType, string itemType)
         {
             var content = this._doc["paths"][path][operationType]["responses"][responseCode]["content"];
@@ -92,9 +92,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
 
         [DataTestMethod]
         [DataRow("/get-applicationjson-dictionary", "get", "200", "application/json", "object", "string")]
-        [DataRow("/get-applicationjson-dictionary-i", "get", "200", "application/json", "object", "integer")]
-        [DataRow("/get-applicationjson-dictionary-ireadonly", "get", "200", "application/json", "object", "number")]
-        [DataRow("/get-applicationjson-dictionary-key", "get", "200", "application/json", "object", "boolean")]
+        [DataRow("/get-applicationjson-dictionary-idictionary", "get", "200", "application/json", "object", "integer")]
+        [DataRow("/get-applicationjson-dictionary-ireadonlydictionary", "get", "200", "application/json", "object", "number")]
+        [DataRow("/get-applicationjson-dictionary-keyvaluepair", "get", "200", "application/json", "object", "boolean")]
         public void Given_OpenApiDocument_Then_It_Should_Return_OperationResponseContentTypeSchemaPropertiesType(string path, string operationType, string responseCode, string contentType, string dataType, string itemType)
         {
             var content = this._doc["paths"][path][operationType]["responses"][responseCode]["content"];

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_ApplicationJson_Dictionary_Tests.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_ApplicationJson_Dictionary_Tests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
+{
+    [TestClass]
+    [TestCategory(Constants.TestCategory)]
+    public class Get_ApplicationJson_Dictionary_Tests
+    {
+        private static HttpClient http = new HttpClient();
+
+        private JObject _doc;
+
+        [TestInitialize]
+        public async Task Init()
+        {
+            var json = await http.GetStringAsync(Constants.OpenApiDocEndpoint).ConfigureAwait(false);
+            this._doc = JsonConvert.DeserializeObject<JObject>(json);
+        }
+
+        [DataTestMethod]
+        [DataRow("/get-applicationjson-dictionary")]
+        [DataRow("/get-applicationjson-dictionary-i")]
+        [DataRow("/get-applicationjson-dictionary-ireadonly")]
+        [DataRow("/get-applicationjson-dictionary-key")]
+        public void Given_OpenApiDocument_Then_It_Should_Return_Path(string path)
+        {
+            var paths = this._doc["paths"];
+
+            paths.Value<JToken>(path).Should().NotBeNull();
+        }
+
+        [DataTestMethod]
+        [DataRow("/get-applicationjson-dictionary", "get")]
+        [DataRow("/get-applicationjson-dictionary-i", "get")]
+        [DataRow("/get-applicationjson-dictionary-ireadonly", "get")]
+        [DataRow("/get-applicationjson-dictionary-key", "get")]
+        public void Given_OpenApiDocument_Then_It_Should_Return_OperationType(string path, string operationType)
+        {
+            var pathItem = this._doc["paths"][path];
+
+            pathItem.Value<JToken>(operationType).Should().NotBeNull();
+        }
+
+        [DataTestMethod]
+        [DataRow("/get-applicationjson-dictionary", "get", "200")]
+        [DataRow("/get-applicationjson-dictionary-i", "get", "200")]
+        [DataRow("/get-applicationjson-dictionary-ireadonly", "get", "200")]
+        [DataRow("/get-applicationjson-dictionary-key", "get", "200")]
+        public void Given_OpenApiDocument_Then_It_Should_Return_OperationResponse(string path, string operationType, string responseCode)
+        {
+            var responses = this._doc["paths"][path][operationType]["responses"];
+
+            responses[responseCode].Should().NotBeNull();
+        }
+
+        [DataTestMethod]
+        [DataRow("/get-applicationjson-dictionary", "get", "200", "application/json")]
+        [DataRow("/get-applicationjson-dictionary-i", "get", "200", "application/json")]
+        [DataRow("/get-applicationjson-dictionary-ireadonly", "get", "200", "application/json")]
+        [DataRow("/get-applicationjson-dictionary-key", "get", "200", "application/json")]
+        public void Given_OpenApiDocument_Then_It_Should_Return_OperationResponseContentType(string path, string operationType, string responseCode, string contentType)
+        {
+            var content = this._doc["paths"][path][operationType]["responses"][responseCode]["content"];
+
+            content[contentType].Should().NotBeNull();
+        }
+
+        [DataTestMethod]
+        [DataRow("/get-applicationjson-dictionary", "get", "200", "application/json", "object")]
+        [DataRow("/get-applicationjson-dictionary-i", "get", "200", "application/json","object")]
+        [DataRow("/get-applicationjson-dictionary-ireadonly", "get", "200", "application/json",  "object")]
+        [DataRow("/get-applicationjson-dictionary-key", "get", "200", "application/json", "object")]
+        public void Given_OpenApiDocument_Then_It_Should_Return_OperationResponseContentTypeSchemaType(string path, string operationType, string responseCode, string contentType, string itemType)
+        {
+            var content = this._doc["paths"][path][operationType]["responses"][responseCode]["content"];
+
+            var schema = content[contentType]["schema"];
+            var type = schema["type"];
+            type.Value<string>().Should().Be(itemType);
+        }
+
+        [DataTestMethod]
+        [DataRow("/get-applicationjson-dictionary", "get", "200", "application/json", "object", "string")]
+        [DataRow("/get-applicationjson-dictionary-i", "get", "200", "application/json", "object", "integer")]
+        [DataRow("/get-applicationjson-dictionary-ireadonly", "get", "200", "application/json", "object", "number")]
+        [DataRow("/get-applicationjson-dictionary-key", "get", "200", "application/json", "object", "boolean")]
+        public void Given_OpenApiDocument_Then_It_Should_Return_OperationResponseContentTypeSchemaPropertiesType(string path, string operationType, string responseCode, string contentType, string dataType, string itemType)
+        {
+            var content = this._doc["paths"][path][operationType]["responses"][responseCode]["content"];
+
+            var schema = content[contentType]["schema"];
+            var additionaltype =schema["additionalProperties"]["type"];
+            additionaltype.Value<string>().Should().Be(itemType);
+        }
+
+    }
+}

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Get_ApplicationJson_DictionaryObject_HttpTrigger.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Get_ApplicationJson_DictionaryObject_HttpTrigger.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp
         [OpenApiOperation(operationId: nameof(Get_ApplicationJson_DictionaryObject_HttpTrigger.Get_ApplicationJson_DictionaryObject), tags: new[] { "dictionary" })]
         [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(DictionaryObjectModel), Description = "The OK response")]
         public static async Task<IActionResult> Get_ApplicationJson_DictionaryObject(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "GET", Route = "get-applicationjson-dictionary")] HttpRequest req,
+            [HttpTrigger(AuthorizationLevel.Anonymous, "GET", Route = "get-applicationjson-dictionaryobject")] HttpRequest req,
             ILogger log)
         {
             var result = new OkResult();

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Get_ApplicationJson_Dictionary_HttpTrigger.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Get_ApplicationJson_Dictionary_HttpTrigger.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp
+{
+    public class Get_ApplicationJson_Dictionary_HttpTrigger
+    {
+        [FunctionName(nameof(Get_ApplicationJson_Dictionary_HttpTrigger.Get_ApplicationJson_Dictionary))]
+        [OpenApiOperation(operationId: nameof(Get_ApplicationJson_Dictionary_HttpTrigger.Get_ApplicationJson_Dictionary), tags: new[] { "dictionary" })]
+        [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(Dictionary<string,string>), Description = "The OK response")]
+        public static async Task<IActionResult> Get_ApplicationJson_Dictionary(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "GET", Route = "get-applicationjson-dictionary")] HttpRequest req,
+            ILogger log)
+        {
+            var result = new OkResult();
+
+            return await Task.FromResult(result).ConfigureAwait(false);
+        }
+
+        [FunctionName(nameof(Get_ApplicationJson_Dictionary_HttpTrigger.Get_ApplicationJson_Dictionary_I))]
+        [OpenApiOperation(operationId: nameof(Get_ApplicationJson_Dictionary_HttpTrigger.Get_ApplicationJson_Dictionary_I), tags: new[] { "dictionary" })]
+        [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(IDictionary<string,int>), Description = "The OK response")]
+        public static async Task<IActionResult> Get_ApplicationJson_Dictionary_I(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "GET", Route = "get-applicationjson-dictionary-i")] HttpRequest req,
+            ILogger log)
+        {
+            var result = new OkResult();
+
+            return await Task.FromResult(result).ConfigureAwait(false);
+        }
+
+        [FunctionName(nameof(Get_ApplicationJson_Dictionary_HttpTrigger.Get_ApplicationJson_Dictionary_Ireadonly))]
+        [OpenApiOperation(operationId: nameof(Get_ApplicationJson_Dictionary_HttpTrigger.Get_ApplicationJson_Dictionary_Ireadonly), tags: new[] { "dictionary" })]
+        [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(IReadOnlyDictionary<string,double>), Description = "The OK response")]
+        public static async Task<IActionResult> Get_ApplicationJson_Dictionary_Ireadonly(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "GET", Route = "get-applicationjson-dictionary-ireadonly")] HttpRequest req,
+            ILogger log)
+        {
+            var result = new OkResult();
+
+            return await Task.FromResult(result).ConfigureAwait(false);
+        }
+
+        [FunctionName(nameof(Get_ApplicationJson_Dictionary_HttpTrigger.Get_ApplicationJson_Dictionary_Key))]
+        [OpenApiOperation(operationId: nameof(Get_ApplicationJson_Dictionary_HttpTrigger.Get_ApplicationJson_Dictionary_Key), tags: new[] { "dictionary" })]
+        [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(KeyValuePair<string,bool>), Description = "The OK response")]
+        public static async Task<IActionResult> Get_ApplicationJson_Dictionary_Key(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "GET", Route = "get-applicationjson-dictionary-key")] HttpRequest req,
+            ILogger log)
+        {
+            var result = new OkResult();
+
+            return await Task.FromResult(result).ConfigureAwait(false);
+        }
+    }
+
+}

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Get_ApplicationJson_Dictionary_HttpTrigger.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Get_ApplicationJson_Dictionary_HttpTrigger.cs
@@ -24,11 +24,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp
             return await Task.FromResult(result).ConfigureAwait(false);
         }
 
-        [FunctionName(nameof(Get_ApplicationJson_Dictionary_HttpTrigger.Get_ApplicationJson_Dictionary_I))]
-        [OpenApiOperation(operationId: nameof(Get_ApplicationJson_Dictionary_HttpTrigger.Get_ApplicationJson_Dictionary_I), tags: new[] { "dictionary" })]
+        [FunctionName(nameof(Get_ApplicationJson_Dictionary_HttpTrigger.Get_ApplicationJson_Dictionary_IDictionary))]
+        [OpenApiOperation(operationId: nameof(Get_ApplicationJson_Dictionary_HttpTrigger.Get_ApplicationJson_Dictionary_IDictionary), tags: new[] { "dictionary" })]
         [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(IDictionary<string,int>), Description = "The OK response")]
-        public static async Task<IActionResult> Get_ApplicationJson_Dictionary_I(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "GET", Route = "get-applicationjson-dictionary-i")] HttpRequest req,
+        public static async Task<IActionResult> Get_ApplicationJson_Dictionary_IDictionary(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "GET", Route = "get-applicationjson-dictionary-idictionary")] HttpRequest req,
             ILogger log)
         {
             var result = new OkResult();
@@ -36,11 +36,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp
             return await Task.FromResult(result).ConfigureAwait(false);
         }
 
-        [FunctionName(nameof(Get_ApplicationJson_Dictionary_HttpTrigger.Get_ApplicationJson_Dictionary_Ireadonly))]
-        [OpenApiOperation(operationId: nameof(Get_ApplicationJson_Dictionary_HttpTrigger.Get_ApplicationJson_Dictionary_Ireadonly), tags: new[] { "dictionary" })]
+        [FunctionName(nameof(Get_ApplicationJson_Dictionary_HttpTrigger.Get_ApplicationJson_Dictionary_IReadOnlyDictionary))]
+        [OpenApiOperation(operationId: nameof(Get_ApplicationJson_Dictionary_HttpTrigger.Get_ApplicationJson_Dictionary_IReadOnlyDictionary), tags: new[] { "dictionary" })]
         [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(IReadOnlyDictionary<string,double>), Description = "The OK response")]
-        public static async Task<IActionResult> Get_ApplicationJson_Dictionary_Ireadonly(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "GET", Route = "get-applicationjson-dictionary-ireadonly")] HttpRequest req,
+        public static async Task<IActionResult> Get_ApplicationJson_Dictionary_IReadOnlyDictionary(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "GET", Route = "get-applicationjson-dictionary-ireadonlydictionary")] HttpRequest req,
             ILogger log)
         {
             var result = new OkResult();
@@ -48,11 +48,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp
             return await Task.FromResult(result).ConfigureAwait(false);
         }
 
-        [FunctionName(nameof(Get_ApplicationJson_Dictionary_HttpTrigger.Get_ApplicationJson_Dictionary_Key))]
-        [OpenApiOperation(operationId: nameof(Get_ApplicationJson_Dictionary_HttpTrigger.Get_ApplicationJson_Dictionary_Key), tags: new[] { "dictionary" })]
+        [FunctionName(nameof(Get_ApplicationJson_Dictionary_HttpTrigger.Get_ApplicationJson_Dictionary_KeyValuePair))]
+        [OpenApiOperation(operationId: nameof(Get_ApplicationJson_Dictionary_HttpTrigger.Get_ApplicationJson_Dictionary_KeyValuePair), tags: new[] { "dictionary" })]
         [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(KeyValuePair<string,bool>), Description = "The OK response")]
-        public static async Task<IActionResult> Get_ApplicationJson_Dictionary_Key(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "GET", Route = "get-applicationjson-dictionary-key")] HttpRequest req,
+        public static async Task<IActionResult> Get_ApplicationJson_Dictionary_KeyValuePair(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "GET", Route = "get-applicationjson-dictionary-keyvaluepair")] HttpRequest req,
             ILogger log)
         {
             var result = new OkResult();


### PR DESCRIPTION
This PR is add Dictionary test code and modify dictionary object route to dictionaryobject

As the existing integration test case haven't covered the dictionary type, other than dictionary object, the PR wil cover the dictionary type. And modify dictionary object route from dictionary to dictionaryobject. Because dictionary trigger has route that name is dictionary.