### PR TITLE
Allow relative URL being used as base URL

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/SwaggerUI.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/SwaggerUI.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
             if (options.IsNullOrDefault())
             {
                 this._baseUrl = baseUrl;
-                this._swaggerUiApiPrefix = prefix;
+                this._swaggerUiApiPrefix = prefix.TrimEnd('/');
                 return this;
             }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/SwaggerUI.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/SwaggerUI.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
 
             this._baseUrl = servers.First().Url;
 
-            absolutePath = new Uri(this._baseUrl).AbsolutePath.TrimEnd('/');
+            absolutePath = new Uri(this._baseUrl, UriKind.RelativeOrAbsolute).AbsolutePath.TrimEnd('/');
             this._swaggerUiApiPrefix = absolutePath;
 
             return this;

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/SwaggerUI.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/SwaggerUI.cs
@@ -59,12 +59,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
 
             var prefix = string.IsNullOrWhiteSpace(routePrefix) ? string.Empty : $"/{routePrefix}";
             var baseUrl = $"{this._req.GetScheme(options)}://{this._req.Host}{prefix}";
-            var absolutePath = default(string);
 
             if (options.IsNullOrDefault())
             {
                 this._baseUrl = baseUrl;
-                this._swaggerUiApiPrefix = absolutePath = prefix;
+                this._swaggerUiApiPrefix = prefix;
                 return this;
             }
 
@@ -85,7 +84,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
             }
 
             this._baseUrl = servers.First().Url;
-            this._swaggerUiApiPrefix = absolutePath = this._baseUrl.TrimEnd('/');
+            this._swaggerUiApiPrefix = this._baseUrl.TrimEnd('/');
 
             return this;
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/SwaggerUI.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/SwaggerUI.cs
@@ -64,10 +64,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
             if (options.IsNullOrDefault())
             {
                 this._baseUrl = baseUrl;
-
-                absolutePath = new Uri(this._baseUrl).AbsolutePath.TrimEnd('/');
-                this._swaggerUiApiPrefix = absolutePath;
-
+                this._swaggerUiApiPrefix = absolutePath = prefix;
                 return this;
             }
 
@@ -88,9 +85,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
             }
 
             this._baseUrl = servers.First().Url;
-
-            absolutePath = new Uri(this._baseUrl, UriKind.RelativeOrAbsolute).AbsolutePath.TrimEnd('/');
-            this._swaggerUiApiPrefix = absolutePath;
+            this._swaggerUiApiPrefix = absolutePath = this._baseUrl.TrimEnd('/');
 
             return this;
         }


### PR DESCRIPTION
Based on the [specification](https://swagger.io/specification/), the Server URL might be relative; and when consumer tries to customize the server list, this might block Swagger UI from rendering.

Use the following configuration to repro:

```csharp
    internal class OpenApiConfigurationOptions : DefaultOpenApiConfigurationOptions
    {
        public override OpenApiInfo Info { get; set; } = new OpenApiInfo()
        {
            Title = "Some REST API",
            Version = "1.0.0",
        };

        public override OpenApiVersionType OpenApiVersion { get; set; } = OpenApiVersionType.V3;

        public override bool IncludeRequestingHostName { get; set; } = false;

        public override List<OpenApiServer> Servers { get; set; } = new List<OpenApiServer>()
        {
            new OpenApiServer()
            {
                Url = "/api",
            },
        };
    }
```

The [`Uri(string)` constructor](https://docs.microsoft.com/en-us/dotnet/api/system.uri.-ctor?view=net-6.0#System_Uri__ctor_System_String_) assumes that the URI string is **absolute**.
