### PR TITLE
Do not consider abstract classes in configuration options

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Resolvers/OpenApiConfigurationResolver.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Resolvers/OpenApiConfigurationResolver.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Resolvers
         {
             var type = assembly.GetLoadableTypes()
                                .SingleOrDefault(p => p.GetInterface("IOpenApiConfigurationOptions", ignoreCase: true).IsNullOrDefault() == false
+                                                  && p.IsAbstract == false
                                                   && p.GetCustomAttribute<ObsoleteAttribute>(inherit: false).IsNullOrDefault() == true);
             if (type.IsNullOrDefault())
             {

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes/FakeOpenApiConfigurationOptions.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes/FakeOpenApiConfigurationOptions.cs
@@ -1,0 +1,6 @@
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes
+{
+    public class FakeOpenApiConfigurationOptions : FakeOpenApiConfigurationOptionsBase
+    {
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes/FakeOpenApiConfigurationOptionsBase.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes/FakeOpenApiConfigurationOptionsBase.cs
@@ -1,0 +1,9 @@
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes
+{
+    // NOTE: this abstract class is for testing the OpenApiConfigurationResolver.Resolve method (and will be ignored)
+    public abstract class FakeOpenApiConfigurationOptionsBase : DefaultOpenApiConfigurationOptions
+    {
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes/FakeOpenApiConfigurationOptionsBase.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes/FakeOpenApiConfigurationOptionsBase.cs
@@ -2,7 +2,6 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes
 {
-    // NOTE: this abstract class is for testing the OpenApiConfigurationResolver.Resolve method (and will be ignored)
     public abstract class FakeOpenApiConfigurationOptionsBase : DefaultOpenApiConfigurationOptions
     {
     }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Resolvers/OpenApiConfigurationResolverTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Resolvers/OpenApiConfigurationResolverTests.cs
@@ -39,5 +39,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Resolvers
 
             result.Should().BeOfType<DefaultOpenApiConfigurationOptions>();
         }
+
+        // NOTE: this abstract class is referenced via the OpenApiConfigurationResolver.Resolve method (and will be ignored)
+        public abstract class TestOpenApiConfigurationOptionsBase : DefaultOpenApiConfigurationOptions
+        {
+        }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Resolvers/OpenApiConfigurationResolverTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Resolvers/OpenApiConfigurationResolverTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Resolvers;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Resolvers
@@ -40,9 +41,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Resolvers
             result.Should().BeOfType<DefaultOpenApiConfigurationOptions>();
         }
 
-        // NOTE: this abstract class is referenced via the OpenApiConfigurationResolver.Resolve method (and will be ignored)
-        public abstract class TestOpenApiConfigurationOptionsBase : DefaultOpenApiConfigurationOptions
+        [TestMethod]
+        public void Given_An_Assembly_With_An_Abstract_Base_Configuration_Then_It_Should_Return_Result()
         {
+            var assembly = Assembly.GetAssembly(typeof(FakeOpenApiConfigurationOptions));
+
+            var result = OpenApiConfigurationResolver.Resolve(assembly);
+
+            result.Should().BeOfType<FakeOpenApiConfigurationOptions>();
+            result.GetType().BaseType.Should().Be(typeof(FakeOpenApiConfigurationOptionsBase)); // This verifies the abstract type was considered in the resolution
         }
     }
 }


### PR DESCRIPTION
We use an abstract base class to share some configuration options. The resolver is picking up that abstract class and thowing an error on the SingleOrDefault.

This is the exception stack:
```
Sequence contains more than one matching element

   at System.Linq.ThrowHelper.ThrowMoreThanOneMatchException()
   at System.Linq.Enumerable.TryGetSingle[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at System.Linq.Enumerable.SingleOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
   at Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Resolvers.OpenApiConfigurationResolver.Resolve(Assembly assembly)
   at Microsoft.Azure.WebJobs.Extensions.OpenApi.OpenApiHttpTriggerContext.get_OpenApiConfigurationOptions()
   at Microsoft.Azure.WebJobs.Extensions.OpenApi.OpenApiTriggerFunctionProvider.RenderSwaggerUI(HttpRequest req, ExecutionContext ctx, ILogger log)
```