### PR TITLE
multipart/form-data in OpenAPI v2 Rendering Workaround (Interim)

### DIFF
--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.InProc/Startup.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.InProc/Startup.cs
@@ -11,7 +11,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.InProc
     {
         public override void Configure(IFunctionsHostBuilder builder)
         {
-            builder.Services.AddSingleton<Fixture>();
+            var fixture = new Fixture();
+            builder.Services.AddSingleton(fixture);
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/DocumentHelperExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/DocumentHelperExtensions.cs
@@ -155,7 +155,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
                                     .Select(p => p.ToOpenApiParameter(namingStrategy, collection))
                                     .ToList();
 
-            // These lines below will be removed when the OpenAPI.NET reflects the issue:
+            // This is the interim solution to resolve:
+            // https://github.com/Azure/azure-functions-openapi-extension/issues/365
+            //
+            // It will be removed when the following issue is resolved:
             // https://github.com/microsoft/OpenAPI.NET/issues/747
             if (version == OpenApiVersionType.V3)
             {
@@ -205,8 +208,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
 
                 parameters.Add(parameter);
             }
-            // These lines above will be removed when the OpenAPI.NET reflects the issue:
-            // https://github.com/microsoft/OpenAPI.NET/issues/747
 
             // // TODO: Should this be forcibly provided?
             // // This needs to be provided separately.

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/DocumentHelperExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/DocumentHelperExtensions.cs
@@ -146,13 +146,67 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
         /// <param name="trigger"><see cref="HttpTriggerAttribute"/> instance.</param>
         /// <param name="namingStrategy"><see cref="NamingStrategy"/> instance to create the JSON schema from .NET Types.</param>
         /// <param name="collection"><see cref="VisitorCollection"/> instance to process parameters.</param>
+        /// <param name="version">OpenAPI spec version.</param>
         /// <returns>List of <see cref="OpenApiParameter"/> instance.</returns>
-        public static List<OpenApiParameter> GetOpenApiParameters(this IDocumentHelper helper, MethodInfo element, HttpTriggerAttribute trigger, NamingStrategy namingStrategy, VisitorCollection collection)
+        public static List<OpenApiParameter> GetOpenApiParameters(this IDocumentHelper helper, MethodInfo element, HttpTriggerAttribute trigger, NamingStrategy namingStrategy, VisitorCollection collection, OpenApiVersionType version)
         {
             var parameters = element.GetCustomAttributes<OpenApiParameterAttribute>(inherit: false)
                                     .Where(p => p.Deprecated == false)
                                     .Select(p => p.ToOpenApiParameter(namingStrategy, collection))
                                     .ToList();
+
+            // These lines below will be removed when the OpenAPI.NET reflects the issue:
+            // https://github.com/microsoft/OpenAPI.NET/issues/747
+            if (version == OpenApiVersionType.V3)
+            {
+                return parameters;
+            }
+
+            var attributes = element.GetCustomAttributes<OpenApiRequestBodyAttribute>(inherit: false);
+            if (!attributes.Any())
+            {
+                return parameters;
+            }
+
+            var contents = attributes.Where(p => p.Deprecated == false)
+                                     .Where(p => p.ContentType == "application/x-www-form-urlencoded" || p.ContentType == "multipart/form-data")
+                                     .Select(p => p.ToOpenApiMediaType(namingStrategy, collection, version));
+            if (!contents.Any())
+            {
+                return parameters;
+            }
+
+            var @ref = contents.First().Schema.Reference;
+            var schemas = helper.GetOpenApiSchemas(new[] { element }.ToList(), namingStrategy, collection);
+            var schema = schemas.SingleOrDefault(p => p.Key == @ref.Id);
+            if (schema.IsNullOrDefault())
+            {
+                return parameters;
+            }
+
+            var properties = schema.Value.Properties;
+            foreach (var property in properties)
+            {
+                var value = property.Value;
+                if ((value.Type == "string" && value.Format == "binary") || (value.Type == "string" && value.Format == "base64"))
+                {
+                    value.Type = "file";
+                    value.Format = null;
+                }
+
+                var parameter = new OpenApiParameter()
+                {
+                    Name = property.Key,
+                    Description = $"[formData]{value.Description}",
+                    Required = bool.TryParse($"{value.Required}", out var result) ? result : false,
+                    Deprecated = value.Deprecated,
+                    Schema = value,
+                };
+
+                parameters.Add(parameter);
+            }
+            // These lines above will be removed when the OpenAPI.NET reflects the issue:
+            // https://github.com/microsoft/OpenAPI.NET/issues/747
 
             // // TODO: Should this be forcibly provided?
             // // This needs to be provided separately.

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
@@ -290,7 +290,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
                              .ToList();
             }
 
-
             return null;
         }
 
@@ -536,7 +535,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
 
             return name;
         }
-
 
         /// <summary>
         /// Gets the sub type of the given <see cref="Type"/>.

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+    <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ByteArrayTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ByteArrayTypeVisitor.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
         /// <inheritdoc />
         public override void Visit(IAcceptor acceptor, KeyValuePair<string, Type> type, NamingStrategy namingStrategy, params Attribute[] attributes)
         {
-            this.Visit(acceptor, name: type.Key, title: null, dataType: "string", dataFormat: "base64", attributes: attributes);
+            this.Visit(acceptor, name: type.Key, title: null, dataType: "string", dataFormat: "binary", attributes: attributes);
         }
 
         /// <inheritdoc />
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
         /// <inheritdoc />
         public override OpenApiSchema ParameterVisit(Type type, NamingStrategy namingStrategy)
         {
-            return this.ParameterVisit(dataType: "string", dataFormat: "base64");
+            return this.ParameterVisit(dataType: "string", dataFormat: "binary");
         }
 
         /// <inheritdoc />
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
         /// <inheritdoc />
         public override OpenApiSchema PayloadVisit(Type type, NamingStrategy namingStrategy)
         {
-            return this.PayloadVisit(dataType: "string", dataFormat: "base64");
+            return this.PayloadVisit(dataType: "string", dataFormat: "binary");
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/Document.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/Document.cs
@@ -208,6 +208,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
 
         private string Render(OpenApiSpecVersion version, OpenApiFormat format)
         {
+            //var serialised = default(string);
+            //using (var sw = new StringWriter())
+            //{
+            //    this.OpenApiDocument.Serialise(sw, version, format);
+            //    serialised = sw.ToString();
+            //}
+
+            //return serialised;
+
+            // This is the interim solution to resolve:
+            // https://github.com/Azure/azure-functions-openapi-extension/issues/365
+            //
+            // It will be removed when the following issue is resolved:
+            // https://github.com/microsoft/OpenAPI.NET/issues/747
             var jserialised = default(string);
             using (var sw = new StringWriter())
             {

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Post_ApplicationJson_ByteArrayObject_Tests.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Post_ApplicationJson_ByteArrayObject_Tests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
         public void Given_OpenApiDocument_Then_It_Should_Return_OperationRequestBody(string path, string operationType)
         {
             var requestBody = this._doc["paths"][path][operationType]["requestBody"];
-          
+
             requestBody.Should().NotBeNull();
         }
 
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
         }
 
         [DataTestMethod]
-        [DataRow("/post-applicationjson-bytearray", "post", "application/octet-stream", "string", "base64")]
+        [DataRow("/post-applicationjson-bytearray", "post", "application/octet-stream", "string", "binary")]
         public void Given_OpenApiDocument_Then_It_Should_Return_OperationRequestBodyContentTypeSchema(string path, string operationType, string contentType, string propertyType, string propertyFormat)
         {
             var content = this._doc["paths"][path][operationType]["requestBody"]["content"];
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
         }
 
         [DataTestMethod]
-        [DataRow("byteArrayObjectModel", "byteArrayValue", "string", "base64")]
+        [DataRow("byteArrayObjectModel", "byteArrayValue", "string", "binary")]
         public void Given_OpenApiDocument_Then_It_Should_Return_ComponentSchemaProperty(string @ref, string propertyName, string propertyType, string propertyFormat)
         {
             var properties = this._doc["components"]["schemas"][@ref]["properties"];

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/ByteArrayTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/ByteArrayTypeVisitorTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
         }
 
         [DataTestMethod]
-        [DataRow("string", "base64", "hello")]
+        [DataRow("string", "binary", "hello")]
         public void Given_Type_When_Visit_Invoked_Then_It_Should_Return_Result(string dataType, string dataFormat, string name)
         {
             var acceptor = new OpenApiSchemaAcceptor();
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
         }
 
         [DataTestMethod]
-        [DataRow("string", "base64")]
+        [DataRow("string", "binary")]
         public void Given_Type_When_ParameterVisit_Invoked_Then_It_Should_Return_Result(string dataType, string dataFormat)
         {
             var result = this._visitor.ParameterVisit(typeof(byte[]), this._strategy);
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
         }
 
         [DataTestMethod]
-        [DataRow("string", "base64")]
+        [DataRow("string", "binary")]
         public void Given_Type_When_PayloadVisit_Invoked_Then_It_Should_Return_Result(string dataType, string dataFormat)
         {
             var result = this._visitor.PayloadVisit(typeof(byte[]), this._strategy);


### PR DESCRIPTION
Related: #365 

This is:

* To provide an interim workaround to properly render the request body with the content type of `multipart/form-data` or `application/x-www-form-urlencoded`.
    * It will be used until [this issue](https://github.com/microsoft/OpenAPI.NET/issues/747) is resolved.