### PR TITLE
Only add unique openApiReferenceIds to the exported types

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
@@ -145,7 +145,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
             var rootSchemas = new Dictionary<string, OpenApiSchema>();
             var schemas = new Dictionary<string, OpenApiSchema>();
 
-            this._acceptor.Types = types.ToDictionary(p => p.GetOpenApiReferenceId(p.IsOpenApiDictionary(), p.IsOpenApiArray(), namingStrategy), p => p);
+            var acceptorTypes = new Dictionary<string, Type>();
+            foreach (var type in types)
+            {
+                var openApiReferenceId = type.GetOpenApiReferenceId(type.IsOpenApiDictionary(), type.IsOpenApiArray(), namingStrategy);
+                if (!acceptorTypes.ContainsKey(openApiReferenceId))
+                {
+                    acceptorTypes.Add(openApiReferenceId, type);
+                }
+            }
+
+            this._acceptor.Types = acceptorTypes;
             this._acceptor.RootSchemas = rootSchemas;
             this._acceptor.Schemas = schemas;
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes/FakeFunctionsWithOverlappingModel.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes/FakeFunctionsWithOverlappingModel.cs
@@ -1,0 +1,36 @@
+using System.Net;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes
+{
+    public class FakeFunctionsWithOverlappingModel
+    {
+        public class OverlappingClass1
+        {
+            public class FakeInternalModel
+            {
+            }
+
+            [OpenApiOperation("test-function")]
+            [OpenApiRequestBody("application/json", typeof(FakeInternalModel))]
+            [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(FakeInternalModel), Summary = "Logs Retrieved.", Description = "Returns the logs matching search parameters.")]
+            public void Run()
+            {
+            }
+        }
+
+        public class OverlappingClass2
+        {
+            public class FakeInternalModel
+            {
+            }
+
+            [OpenApiOperation("test-function")]
+            [OpenApiRequestBody("application/json", typeof(FakeInternalModel))]
+            [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(FakeInternalModel), Summary = "Logs Retrieved.", Description = "Returns the logs matching search parameters.")]
+            public void Run()
+            {
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/DocumentHelperTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/DocumentHelperTests.cs
@@ -82,7 +82,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
             schemas["FakeGenericModel_FakeOtherClassModel"].Properties.Should().ContainKey("Value");
             schemas["FakeGenericModel_FakeOtherClassModel"].Properties["Value"].Properties.Should().ContainKey("FirstName");
             schemas["FakeGenericModel_FakeOtherClassModel"].Properties["Value"].Properties.Should().ContainKey("LastName");
+        }
 
+        [TestMethod]
+        public void GetOpenApiSchemas_Result_Should_Contain_No_Overlapping_OpenApiReferences()
+        {
+            var namingStrategy = new DefaultNamingStrategy();
+            var filter = new RouteConstraintFilter();
+            var acceptor = new OpenApiSchemaAcceptor();
+            var documentHelper = new DocumentHelper(filter, acceptor);
+            var visitorCollection = VisitorCollection.CreateInstance();
+
+            var methods = typeof(FakeFunctionsWithOverlappingModel.OverlappingClass1).GetMethods()
+                .Concat(typeof(FakeFunctionsWithOverlappingModel.OverlappingClass2).GetMethods()).ToList();
+
+            var schemas = documentHelper.GetOpenApiSchemas(methods, namingStrategy, visitorCollection);
+
+            schemas.Should().NotBeNull();
+            schemas.Count.Should().Be(1);
+
+            schemas.Where(x => x.Key == "FakeInternalModel").Count().Should().Be(1);
+
+            schemas["FakeInternalModel"].Type.Should().Be("object");
         }
     }
 }


### PR DESCRIPTION
Multiple types might be used for both input and output, getting the same openApiReferenceId.

This PR makes sure only the first openApiReference gets added. Fixes #407 