### PR TITLE
Adds new function for OpenApi v3

### DIFF
--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/DocumentTests.cs
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/DocumentTests.cs
@@ -474,7 +474,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         }
 
         [TestMethod]
-        public async Task Given_ServerDetails_WithNullRoutePrefix_When_RenderAsync_Invoked_Then_It_Should_Return_Result_OpenApi2_0()
+        public async Task Given_ServerDetails_WithNullRoutePrefix_When_RenderAsync_Invoked_Then_It_Should_Return_Result_OpenApiV2()
         {
             var helper = new Mock<IDocumentHelper>();
 
@@ -501,7 +501,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         }
 
         [TestMethod]
-        public async Task Given_ServerDetails_WithNullRoutePrefix_When_RenderAsync_Invoked_Then_It_Should_Return_Result_OpenApi3_0()
+        public async Task Given_ServerDetails_WithNullRoutePrefix_When_RenderAsync_Invoked_Then_It_Should_Return_Result_OpenApiV3()
         {
             var helper = new Mock<IDocumentHelper>();
 
@@ -524,8 +524,8 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
 
             var uri = new Uri((string)json?.servers[0].url);
 
-            (uri.Scheme).Should().BeEquivalentTo(scheme);
-            (uri.Host).Should().BeEquivalentTo(host);
+            uri.Scheme.Should().BeEquivalentTo(scheme);
+            uri.Host.Should().BeEquivalentTo(host);
         }
 
         [TestMethod]

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/DocumentTests.cs
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/DocumentTests.cs
@@ -522,6 +522,10 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
 
             dynamic json = JObject.Parse(result);
 
+
+            ((object)json?.servers).Should().NotBeNull();
+            ((int)json?.servers.Count).Should().BeGreaterThan(0);
+
             var uri = new Uri((string)json?.servers[0].url);
 
             uri.Scheme.Should().BeEquivalentTo(scheme);

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/DocumentTests.cs
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/DocumentTests.cs
@@ -474,7 +474,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         }
 
         [TestMethod]
-        public async Task Given_ServerDetails_WithNullRoutePrefix_When_RenderAsync_Invoked_Then_It_Should_Return_Result()
+        public async Task Given_ServerDetails_WithNullRoutePrefix_When_RenderAsync_Invoked_Then_It_Should_Return_Result_OpenApi2_0()
         {
             var helper = new Mock<IDocumentHelper>();
 
@@ -498,6 +498,34 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
             ((string)json?.host).Should().BeEquivalentTo(host);
             ((string)json?.basePath).Should().BeEquivalentTo(null);
             ((string)json?.schemes[0]).Should().BeEquivalentTo(scheme);
+        }
+
+        [TestMethod]
+        public async Task Given_ServerDetails_WithNullRoutePrefix_When_RenderAsync_Invoked_Then_It_Should_Return_Result_OpenApi3_0()
+        {
+            var helper = new Mock<IDocumentHelper>();
+
+            var scheme = "https";
+            var host = "localhost";
+            string routePrefix = null;
+
+            var url = $"{scheme}://{host}";
+            var req = new Mock<IHttpRequestDataObject>();
+            req.SetupGet(p => p.Scheme).Returns(scheme);
+            req.SetupGet(p => p.Host).Returns(new HostString(host));
+
+            var doc = new Document(helper.Object);
+
+            var result = await doc.InitialiseDocument()
+                                  .AddServer(req.Object, routePrefix)
+                                  .RenderAsync(OpenApiSpecVersion.OpenApi3_0, OpenApiFormat.Json);
+
+            dynamic json = JObject.Parse(result);
+
+            var uri = new Uri((string)json?.servers[0].url);
+
+            (uri.Scheme).Should().BeEquivalentTo(scheme);
+            (uri.Host).Should().BeEquivalentTo(host);
         }
 
         [TestMethod]


### PR DESCRIPTION
Adds "Given_ServerDetails_WithNullRoutePrefix_When_RenderAsync_Invoked_Then_It_Should_Return_Result_OpenApi3_0" function to "test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/DocumentTests.cs" and modified "Given_ServerDetails_WithNullRoutePrefix_When_RenderAsync_Invoked_Then_It_Should_Return_Result" to "Given_ServerDetails_WithNullRoutePrefix_When_RenderAsync_Invoked_Then_It_Should_Return_Result_OpenApi2_0"