### PR TITLE
Use reference types for Enum properties

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
@@ -132,11 +132,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
         {
             var requests = elements.SelectMany(p => p.GetCustomAttributes<OpenApiRequestBodyAttribute>(inherit: false))
                                    .Select(p => p.BodyType);
-            var enumRequestParams = elements.SelectMany(p => p.GetCustomAttributes<OpenApiParameterAttribute>(inherit: false))
-                .Select(p => p.Type).Where(t => t.IsUnflaggedEnumType());
             var responses = elements.SelectMany(p => p.GetCustomAttributes<OpenApiResponseWithBodyAttribute>(inherit: false))
                                     .Select(p => p.BodyType);
-            var types = requests.Union(responses).Union(enumRequestParams)
+            var types = requests.Union(responses)
                                 .Select(p => p.IsOpenApiArray() || p.IsOpenApiDictionary() ? p.GetOpenApiSubType() : p)
                                 .Distinct()
                                 .Where(p => p.IsUnflaggedEnumType() || !p.IsSimpleType())
@@ -163,7 +161,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
 
             this._acceptor.Accept(collection, namingStrategy);
 
-            var union = rootSchemas.Concat(schemas.Where(p => !rootSchemas.Keys.Contains(p.Key)))
+            var union = schemas.Concat(rootSchemas.Where(p => !schemas.Keys.Contains(p.Key)))
                                .Distinct()
                                .Where(p => p.Key.ToUpperInvariant() != "OBJECT")
                                .OrderBy(p => p.Key)

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
 
             if (type.IsUnflaggedEnumType())
             {
-                isReferential = false;
+                isReferential = true;
             }
 
             if (type.IsJObjectType())

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/OpenApiExampleFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/OpenApiExampleFactory.cs
@@ -1,8 +1,9 @@
 using System;
-
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.OpenApi.Any;
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
 {
@@ -17,13 +18,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
         /// <param name="instance">instance.</param>
         /// <param name="settings"><see cref="JsonSerializerSettings"/>settings.</param>
         /// <returns><see cref="IOpenApiAny"/> instance.</returns>
-        public static IOpenApiAny CreateInstance<T>(T instance, JsonSerializerSettings settings)
+        public static IOpenApiAny CreateInstance<T>(T instance, JsonSerializerSettings settings, NamingStrategy namingStrategy)
         {
             Type type = typeof(T);
             var @enum = Type.GetTypeCode(type);
             var openApiExampleValue = default(IOpenApiAny);
-
-            switch (@enum)
+            if (type.IsUnflaggedEnumType())
+            {
+                openApiExampleValue = new OpenApiString((instance as Enum).ToDisplayName(namingStrategy));
+            }
+            else switch (@enum)
             {
                 case TypeCode.Int16:
                     openApiExampleValue = new OpenApiInteger(Convert.ToInt16(instance));

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Resolvers/OpenApiExampleResolver.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Resolvers/OpenApiExampleResolver.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Resolvers
             var resolver = new DefaultContractResolver() { NamingStrategy = namingStrategy ?? new DefaultNamingStrategy() };
             settings.ContractResolver = resolver;
 
-            var openApiExampleValue = OpenApiExampleFactory.CreateInstance<T>(instance,settings);
+            var openApiExampleValue = OpenApiExampleFactory.CreateInstance<T>(instance,settings, namingStrategy);
             var example = new OpenApiExample()
             {
                 Summary = summary,

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/StringEnumTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/StringEnumTypeVisitor.cs
@@ -36,21 +36,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
 
             return isVisitable;
         }
-        private string GetEnumTypeDescription(Type type)
-        {
-            
-            var descriptions = type.GetCustomAttributes(false).OfType<DescriptionAttribute>().Select(d => d.Description).ToList();
-            foreach (var enumValue in type.GetEnumValues())
-            {
-                descriptions.AddRange(type.GetMember(enumValue.ToString()).SelectMany(t => t.GetCustomAttributes(false)).OfType<DescriptionAttribute>().Select(d => $"{enumValue}: {d.Description}"));
-            }
-            if (descriptions.Any())
-            {
-                return string.Join("\n", descriptions);
-            }
-            return null;
-                
-        }
 
         /// <inheritdoc />
         public override void Visit(IAcceptor acceptor, KeyValuePair<string, Type> type, NamingStrategy namingStrategy, params Attribute[] attributes)
@@ -144,7 +129,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
         /// <inheritdoc />
         public override OpenApiSchema PayloadVisit(Type type, NamingStrategy namingStrategy)
         {
-            var schema = this.ParameterVisit(dataType: "string", dataFormat: null);
+            var schema = this.PayloadVisit(dataType: "string", dataFormat: null);
 
             // Adds enum values to the schema.
             var enums = type.ToOpenApiStringCollection(namingStrategy);

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Configurations/OpenApiConfigurationOptionsTests.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Configurations/OpenApiConfigurationOptionsTests.cs
@@ -3,7 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 
 using FluentAssertions;
-
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests.Serialization;
 using Microsoft.OpenApi.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests.OpenApiInfo
         public async Task Init()
         {
             this._json = await http.GetStringAsync(Constants.OpenApiDocEndpoint).ConfigureAwait(false);
-            this._doc = JsonConvert.DeserializeObject<OpenApiDocument>(this._json);
+            this._doc = JsonConvert.DeserializeObject<OpenApiDocument>(this._json, new OpenApiAnyConverter());
         }
 
         [TestMethod]

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_Path_ParameterExamples_Tests.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_Path_ParameterExamples_Tests.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
         [DataRow("/get-path-parameter-examples", "get", "dateTimeOffsetParameter", "path", true)]
         [DataRow("/get-path-parameter-examples", "get", "booleanParameter", "path", true)]
         [DataRow("/get-path-parameter-examples", "get", "guidParameter", "path", true)]
+        [DataRow("/get-path-parameter-examples", "get", "simpleEnumParameter", "path", true)]
         public void Given_OpenApiDocument_Then_It_Should_Return_OperationParameter(string path, string operationType, string name, string @in, bool required)
         {
             var parameters = this._doc["paths"][path][operationType]["parameters"].Children();
@@ -84,6 +85,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
         [DataRow("/get-path-parameter-examples", "get", "dateTimeOffsetParameter", "string")]
         [DataRow("/get-path-parameter-examples", "get", "booleanParameter", "boolean")]
         [DataRow("/get-path-parameter-examples", "get", "guidParameter", "string")]
+        [DataRow("/get-path-parameter-examples", "get", "simpleEnumParameter", "string")]
         public void Given_OpenApiDocument_Then_It_Should_Return_OperationParameterSchema(string path, string operationType, string name, string dataType)
         {
             var parameters = this._doc["paths"][path][operationType]["parameters"].Children();
@@ -254,6 +256,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
         [DataTestMethod]
         [DataRow("/get-path-parameter-examples", "get", "guidParameter", "guidValue1", "74be27de-1e4e-49d9-b579-fe0b331d3642")]
         public void Given_OpenApiDocument_GuidType_Then_It_Should_Return_OperationParameterExamples(string path, string operationType, string name, string exampleName, string exampleValue)
+        {
+            var parameters = this._doc["paths"][path][operationType]["parameters"].Children();
+            var parameter = parameters.SingleOrDefault(p => p["name"].Value<string>() == name);
+
+            var examples = parameter["examples"];
+
+            examples[exampleName]["value"].Value<string>().Should().Be(exampleValue);
+        }
+
+        [DataTestMethod]
+        [DataRow("/get-path-parameter-examples", "get", "simpleEnumParameter", "simpleEnumTypeValue1", "titleCase")]
+        public void Given_OpenApiDocument_SimpleEnumType_Then_It_Should_Return_OperationParameterExamples(string path, string operationType, string name, string exampleName, string exampleValue)
         {
             var parameters = this._doc["paths"][path][operationType]["parameters"].Children();
             var parameter = parameters.SingleOrDefault(p => p["name"].Value<string>() == name);

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_Query_ParameterExamples_Tests.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_Query_ParameterExamples_Tests.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
         [DataRow("/get-query-parameter-examples", "get", "booleanParameter", "query", true)]
         [DataRow("/get-query-parameter-examples", "get", "guidParameter", "query", true)]
         [DataRow("/get-query-parameter-examples", "get", "byteArrayParameter", "query", true)]
+        [DataRow("/get-query-parameter-examples", "get", "simpleEnumParameter", "query", true)]
         public void Given_OpenApiDocument_Then_It_Should_Return_OperationParameter(string path, string operationType, string name, string @in, bool required)
         {
             var parameters = this._doc["paths"][path][operationType]["parameters"].Children();
@@ -86,6 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
         [DataRow("/get-query-parameter-examples", "get", "booleanParameter", "boolean")]
         [DataRow("/get-query-parameter-examples", "get", "guidParameter", "string")]
         [DataRow("/get-query-parameter-examples", "get", "byteArrayParameter", "string")]
+        [DataRow("/get-query-parameter-examples", "get", "simpleEnumParameter", "string")]
         public void Given_OpenApiDocument_Then_It_Should_Return_OperationParameterSchema(string path, string operationType, string name, string dataType)
         {
             var parameters = this._doc["paths"][path][operationType]["parameters"].Children();
@@ -276,6 +278,35 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
 
             examples[exampleName1]["value"].Value<string>().Should().Be(exampleValue1);
             examples[exampleName2]["value"].Value<string>().Should().Be(exampleValue2);
+        }
+
+        [DataTestMethod]
+        [DataRow("/get-query-parameter-examples", "get", "simpleEnumParameter", "simple", "titleCase", "values")]
+        public void Given_OpenApiDocument_SimpleEnumType_Then_It_Should_Return_EnumValues(string path, string operationType, string name, params string[] values)
+        {
+            var parameters = this._doc["paths"][path][operationType]["parameters"].Children();
+            var parameter = parameters.SingleOrDefault(p => p["name"].Value<string>() == name);
+
+            var schema = parameter["schema"];
+            // In OAS v2, enum query/url params must be inline. v3 supports using $ref.
+            // (we currently have the same logic for v2 and v3, but ideally v3 should be using $ref instead)
+            for(var i = 0; i < values.Length; i++)
+            {
+                schema["enum"][i].Value<string>().Should().Be(values[i]);
+            }
+
+        }
+
+        [DataTestMethod]
+        [DataRow("/get-query-parameter-examples", "get", "simpleEnumParameter", "simpleEnumTypeValue1", "titleCase")]
+        public void Given_OpenApiDocument_SimpleEnumType_Then_It_Should_Return_OperationParameterExamples(string path, string operationType, string name, string exampleName1, string exampleValue1)
+        {
+            var parameters = this._doc["paths"][path][operationType]["parameters"].Children();
+            var parameter = parameters.SingleOrDefault(p => p["name"].Value<string>() == name);
+
+            var examples = parameter["examples"];
+
+            examples[exampleName1]["value"].Value<string>().Should().Be(exampleValue1);
         }
 
         [DataTestMethod]

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/OpenApiInfo/OpenApiInfoTests.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/OpenApiInfo/OpenApiInfoTests.cs
@@ -2,14 +2,14 @@ using System.Net.Http;
 using System.Threading.Tasks;
 
 using FluentAssertions;
-
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests.Serialization;
 using Microsoft.OpenApi.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests.OpenApiInfo
-{
+{    
     [TestClass]
     [TestCategory(Constants.TestCategory)]
     public class OpenApiInfoTests
@@ -22,8 +22,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests.OpenApiInfo
         [TestInitialize]
         public async Task Init()
         {
-            this._json = await http.GetStringAsync(Constants.OpenApiDocEndpoint).ConfigureAwait(false);
-            this._doc = JsonConvert.DeserializeObject<OpenApiDocument>(this._json);
+            this._json = await http.GetStringAsync(Constants.OpenApiDocEndpoint).ConfigureAwait(false);            
+            this._doc = JsonConvert.DeserializeObject<OpenApiDocument>(this._json, new OpenApiAnyConverter());        
         }
 
         [TestMethod]

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Serialization/OpenApiAnyConverter.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Serialization/OpenApiAnyConverter.cs
@@ -1,0 +1,36 @@
+using Microsoft.OpenApi.Any;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests.Serialization
+{
+    /// <summary>
+    /// IOpenApiAny types inside OpenApiDocument can't be deserialized without knowing which concrete type to deserialize to.
+    /// This custom converter deserializes json to OpenApiString type.
+    /// </summary>
+    public class OpenApiAnyConverter : JsonConverter<IOpenApiAny>
+    {
+        public override IOpenApiAny ReadJson(JsonReader reader, Type objectType, IOpenApiAny existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+
+            var s = (string)reader.Value;
+            return new OpenApiString(s);
+        }
+
+        public override void WriteJson(JsonWriter writer, IOpenApiAny value, JsonSerializer serializer)
+        {
+            //not used
+            var t = JToken.FromObject(value);
+            t.WriteTo(writer);
+        }
+    }
+}

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Examples/SimpleEnumTypeParameterExample.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Examples/SimpleEnumTypeParameterExample.cs
@@ -1,0 +1,18 @@
+using System;
+
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Resolvers;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Models;
+using Newtonsoft.Json.Serialization;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Examples
+{
+    public class SimpleEnumTypeParameterExample : OpenApiExample<SimpleEnumType>
+    {
+        public override IOpenApiExample<SimpleEnumType> Build(NamingStrategy namingStrategy = null)
+        {
+            this.Examples.Add(OpenApiExampleResolver.Resolve("simpleEnumTypeValue1", SimpleEnumType.TitleCase, namingStrategy));
+            return this;
+        }
+    }
+}

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Get_Path_ParameterExamples_HttpTrigger.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Get_Path_ParameterExamples_HttpTrigger.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Examples;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 
@@ -29,6 +30,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp
         [OpenApiParameter(name: "dateTimeOffsetParameter", In = ParameterLocation.Path, Required = true, Example = typeof(DateTimeOffsetParameterExample), Type = typeof(DateTimeOffset), Description = "The **dateTimeOffset** parameter")]
         [OpenApiParameter(name: "booleanParameter", In = ParameterLocation.Path, Required = true, Example = typeof(BooleanParameterExample), Type = typeof(bool), Description = "The **boolean** parameter")]
         [OpenApiParameter(name: "guidParameter", In = ParameterLocation.Path, Required = true, Example = typeof(GuidParameterExample), Type = typeof(Guid), Description = "The **guid** parameter")]
+        [OpenApiParameter(name: "simpleEnumParameter", In = ParameterLocation.Path, Required = true, Type = typeof(SimpleEnumType), Description = "The **SimpleEnumType** parameter")]
         [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "text/plain", bodyType: typeof(string), Description = "The OK response")]
         public static async Task<IActionResult> Get_Path_ParameterExamples(
             [HttpTrigger(AuthorizationLevel.Anonymous, "GET", Route = "get-path-parameter-examples")] HttpRequest req,

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Get_Path_ParameterExamples_HttpTrigger.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Get_Path_ParameterExamples_HttpTrigger.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp
         [OpenApiParameter(name: "dateTimeOffsetParameter", In = ParameterLocation.Path, Required = true, Example = typeof(DateTimeOffsetParameterExample), Type = typeof(DateTimeOffset), Description = "The **dateTimeOffset** parameter")]
         [OpenApiParameter(name: "booleanParameter", In = ParameterLocation.Path, Required = true, Example = typeof(BooleanParameterExample), Type = typeof(bool), Description = "The **boolean** parameter")]
         [OpenApiParameter(name: "guidParameter", In = ParameterLocation.Path, Required = true, Example = typeof(GuidParameterExample), Type = typeof(Guid), Description = "The **guid** parameter")]
-        [OpenApiParameter(name: "simpleEnumParameter", In = ParameterLocation.Path, Required = true, Type = typeof(SimpleEnumType), Description = "The **SimpleEnumType** parameter")]
+        [OpenApiParameter(name: "simpleEnumParameter", In = ParameterLocation.Path, Required = true, Example = typeof(SimpleEnumTypeParameterExample), Type = typeof(SimpleEnumType), Description = "The **SimpleEnumType** parameter")]
         [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "text/plain", bodyType: typeof(string), Description = "The OK response")]
         public static async Task<IActionResult> Get_Path_ParameterExamples(
             [HttpTrigger(AuthorizationLevel.Anonymous, "GET", Route = "get-path-parameter-examples")] HttpRequest req,

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Get_Query_ParameterExamples_HttpTrigger.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Get_Query_ParameterExamples_HttpTrigger.cs
@@ -32,8 +32,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp
         [OpenApiParameter(name: "booleanParameter", In = ParameterLocation.Query, Required = true, Example = typeof(BooleanParameterExample), Type = typeof(bool), Description = "The **boolean** parameter")]
         [OpenApiParameter(name: "guidParameter", In = ParameterLocation.Query, Required = true, Example = typeof(GuidParameterExample), Type = typeof(Guid), Description = "The **guid** parameter")]
         [OpenApiParameter(name: "byteArrayParameter", In = ParameterLocation.Query, Required = true, Example = typeof(ByteArrayParameterExample), Type = typeof(byte[]), Description = "The **byteArray** parameter")]
-        [OpenApiParameter(name: "simpleEnumParameter", In = ParameterLocation.Query, Required = true, Type = typeof(SimpleEnumType2), Description = "The **SimpleEnumType** parameter")]
-        [OpenApiParameter(name: "simpleEnumListParameter", In = ParameterLocation.Query, Required = true, Explode =false, Type = typeof(List<SimpleEnumType>), Description = "The **SimpleEnumType List** parameter")]
+        [OpenApiParameter(name: "simpleEnumParameter", In = ParameterLocation.Query, Required = true, Example = typeof(SimpleEnumTypeParameterExample), Type = typeof(SimpleEnumType), Description = "The **SimpleEnumType** parameter")]
         [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "text/plain", bodyType: typeof(string), Description = "The OK response")]
         public static async Task<IActionResult> Get_Query_ParameterExamples(
             [HttpTrigger(AuthorizationLevel.Anonymous, "GET", Route = "get-query-parameter-examples")] HttpRequest req,

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Get_Query_ParameterExamples_HttpTrigger.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Get_Query_ParameterExamples_HttpTrigger.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -7,6 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Examples;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 
@@ -30,6 +32,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp
         [OpenApiParameter(name: "booleanParameter", In = ParameterLocation.Query, Required = true, Example = typeof(BooleanParameterExample), Type = typeof(bool), Description = "The **boolean** parameter")]
         [OpenApiParameter(name: "guidParameter", In = ParameterLocation.Query, Required = true, Example = typeof(GuidParameterExample), Type = typeof(Guid), Description = "The **guid** parameter")]
         [OpenApiParameter(name: "byteArrayParameter", In = ParameterLocation.Query, Required = true, Example = typeof(ByteArrayParameterExample), Type = typeof(byte[]), Description = "The **byteArray** parameter")]
+        [OpenApiParameter(name: "simpleEnumParameter", In = ParameterLocation.Query, Required = true, Type = typeof(SimpleEnumType2), Description = "The **SimpleEnumType** parameter")]
+        [OpenApiParameter(name: "simpleEnumListParameter", In = ParameterLocation.Query, Required = true, Explode =false, Type = typeof(List<SimpleEnumType>), Description = "The **SimpleEnumType List** parameter")]
         [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "text/plain", bodyType: typeof(string), Description = "The OK response")]
         public static async Task<IActionResult> Get_Query_ParameterExamples(
             [HttpTrigger(AuthorizationLevel.Anonymous, "GET", Route = "get-query-parameter-examples")] HttpRequest req,
@@ -39,5 +43,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp
 
             return await Task.FromResult(result).ConfigureAwait(false);
         }
+
     }
 }

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Models/BaseObjectModel.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Models/BaseObjectModel.cs
@@ -1,4 +1,8 @@
 using System.Collections.Generic;
+using System.ComponentModel;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Models
 {
@@ -14,5 +18,33 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Models
         public BaseSubObjectModel SubObjectValue { get; set; }
         public List<object> BaseObjectList { get; set; }
         public Dictionary<string, object> BaseObjectDictionary { get; set; }
+    [OpenApiProperty(Description = "foo")]
+        public SimpleEnumType SimpleEnumValue1 { get; set; }
+    [OpenApiProperty(Description = "bar")]
+        public SimpleEnumType SimpleEnumValue2 { get; set; }
     }
-}
+    [Description("enum definition description")]
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum SimpleEnumType
+    {
+    [Description("value 1 definition description")]
+        Simple,
+    [Description("value 2 definition description")]
+        TitleCase,
+        Values
+    }
+    [Description("enum definition description")]
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum SimpleEnumType2
+    {
+        [Description("value 1 definition description")]
+        Simple,
+        [Description("value 2 definition description")]
+        TitleCase,
+        Values
+    }
+    public class BaseObjectModel2
+    {
+        public string BaseObjectValue { get; set; }
+    }
+    }

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Models/BaseObjectModel.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Models/BaseObjectModel.cs
@@ -18,33 +18,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Models
         public BaseSubObjectModel SubObjectValue { get; set; }
         public List<object> BaseObjectList { get; set; }
         public Dictionary<string, object> BaseObjectDictionary { get; set; }
-    [OpenApiProperty(Description = "foo")]
         public SimpleEnumType SimpleEnumValue1 { get; set; }
-    [OpenApiProperty(Description = "bar")]
         public SimpleEnumType SimpleEnumValue2 { get; set; }
     }
-    [Description("enum definition description")]
     [JsonConverter(typeof(StringEnumConverter))]
     public enum SimpleEnumType
     {
-    [Description("value 1 definition description")]
         Simple,
-    [Description("value 2 definition description")]
         TitleCase,
         Values
     }
-    [Description("enum definition description")]
-    [JsonConverter(typeof(StringEnumConverter))]
-    public enum SimpleEnumType2
-    {
-        [Description("value 1 definition description")]
-        Simple,
-        [Description("value 2 definition description")]
-        TitleCase,
-        Values
-    }
-    public class BaseObjectModel2
-    {
-        public string BaseObjectValue { get; set; }
-    }
-    }
+    
+  
+}

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Post_ApplicationJson_NullableObject_HttpTrigger copy.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Post_ApplicationJson_NullableObject_HttpTrigger copy.cs
@@ -169,5 +169,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp
 
             return await Task.FromResult(result).ConfigureAwait(false);
         }
+
+        [FunctionName(nameof(Post_ApplicationJson_NullableObject_HttpTrigger.Post_ApplicationJson_BaseObject))]
+        [OpenApiOperation(operationId: nameof(Post_ApplicationJson_NullableObject_HttpTrigger.Post_ApplicationJson_BaseObject), tags: new[] { "nullable" })]
+        [OpenApiRequestBody(contentType: "text/plain", bodyType: typeof(BaseObjectModel2), Required = true, Description = "Base Object Model")]
+        [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(NullableObjectModel), Description = "The OK response")]
+        public static async Task<IActionResult> Post_ApplicationJson_BaseObject(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "POST", Route = "post-applicationjson-baseobject")] HttpRequest req,
+            ILogger log)
+        {
+            var result = new OkResult();
+
+            return await Task.FromResult(result).ConfigureAwait(false);
+        }
     }
 }

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Post_ApplicationJson_NullableObject_HttpTrigger copy.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Post_ApplicationJson_NullableObject_HttpTrigger copy.cs
@@ -168,7 +168,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp
             var result  = new OkResult();
 
             return await Task.FromResult(result).ConfigureAwait(false);
-        }
-        
+        }        
     }
 }

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Post_ApplicationJson_NullableObject_HttpTrigger copy.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Post_ApplicationJson_NullableObject_HttpTrigger copy.cs
@@ -169,18 +169,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp
 
             return await Task.FromResult(result).ConfigureAwait(false);
         }
-
-        [FunctionName(nameof(Post_ApplicationJson_NullableObject_HttpTrigger.Post_ApplicationJson_BaseObject))]
-        [OpenApiOperation(operationId: nameof(Post_ApplicationJson_NullableObject_HttpTrigger.Post_ApplicationJson_BaseObject), tags: new[] { "nullable" })]
-        [OpenApiRequestBody(contentType: "text/plain", bodyType: typeof(BaseObjectModel2), Required = true, Description = "Base Object Model")]
-        [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(NullableObjectModel), Description = "The OK response")]
-        public static async Task<IActionResult> Post_ApplicationJson_BaseObject(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "POST", Route = "post-applicationjson-baseobject")] HttpRequest req,
-            ILogger log)
-        {
-            var result = new OkResult();
-
-            return await Task.FromResult(result).ConfigureAwait(false);
-        }
+        
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/ObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/ObjectTypeVisitorTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
         }
 
         [DataTestMethod]
-        [DataRow(typeof(FakeModel), "object", null, 2, 3, "fakeModel")]
+        [DataRow(typeof(FakeModel), "object", null, 2, 4, "fakeModel")]
         [DataRow(typeof(FakeRequiredModel), "object", null, 1, 0, "fakeRequiredModel")]
         [DataRow(typeof(FakeRecursiveModel), "object", null, 1, 2, "fakeRecursiveModel")]
         public void Given_Type_When_Visit_Invoked_Then_It_Should_Return_Result(Type objectType, string dataType, string dataFormat, int requiredCount, int rootSchemaCount, string referenceId)


### PR DESCRIPTION
This fixes #153  by using reference types for Enum properties.
Enums in query/path url parameters are NOT updated to use reference types. In OAS v2, enum query/url params must be inline. v3 supports using $ref. To implement this, we need to have the target version in `StringEnumTypeVisitor.PayloadVisit / ParameterVisit` to determine whether to return a $ref or inline enums, which would require some structural changes. Maybe there's a better way to do that, perhaps after the visitors while rendering the doc, but I would need some more guidance.

## Breaking changes:
If the project contains multiple Enum type definitions with the same name (for example, https://github.com/Azure/azure-functions-openapi-extension/issues/153#issuecomment-932121161 ), these will now conflict. One possible workaround would be to provide a type name callback/delegate, eg `Func<Type, string> GetTypeName`, where consumers of this lib who have this conflict could provide an alternative type name, eg by including the parent namespace.