### PR TITLE
V2/ Merge `OpenApiHttpTriggerAuthorization` with `OpenApiConfigurationOptions`

### DIFF
--- a/.github/workflows/main-build.yaml
+++ b/.github/workflows/main-build.yaml
@@ -9,7 +9,9 @@ on:
     - feature/*
     - hotfix/*
     - v2
+    - v2-feature/*
     - v3
+    - v3-feature/*
 
 jobs:
   build_and_test:

--- a/builds/build-dev.yaml
+++ b/builds/build-dev.yaml
@@ -8,7 +8,9 @@ trigger:
     - feature/*
     - hotfix/*
     - v2
+    - v2-feature/*
     - v3
+    - v3-feature/*
 
 pr: none
 

--- a/docs/openapi-in-proc.md
+++ b/docs/openapi-in-proc.md
@@ -73,52 +73,28 @@ namespace MyFunctionApp
                                     IncludeRequestingHostName = true,
                                     ForceHttps = false,
                                     ForceHttp = false,
+                                    Security = new OpenApiHttpTriggerAuthorization(req =>
+                                    {
+                                        var result = default(OpenApiAuthorizationResult);
+
+                                        var authtoken = (string)req.Headers["Authorization"];
+                                        if (authtoken.IsNullOrWhiteSpace())
+                                        {
+                                            result = new OpenApiAuthorizationResult()
+                                            {
+                                                StatusCode = HttpStatusCode.Unauthorized,
+                                                ContentType = "text/plain",
+                                                Payload = "Unauthorized",
+                                            };
+
+                                            return Task.FromResult(result);
+                                        }
+
+                                        return Task.FromResult(result);
+                                    }),
                                 };
 
                                 return options;
-                            });
-            /* ⬆️⬆️⬆️ Add this ⬆️⬆️⬆️ */
-        }
-    }
-}
-```
-
-### Injecting `OpenApiHttpTriggerAuthorization` during Startup ###
-
-You may want to inject the `OpenApiHttpTriggerAuthorization` instance during startup, through the `Startup.cs` class. Here's the example:
-
-```csharp
-[assembly: FunctionsStartup(typeof(MyFunctionApp.Startup))]
-namespace MyFunctionApp
-{
-    public class Startup : FunctionsStartup
-    {
-        public override void Configure(IFunctionsHostBuilder builder)
-        {
-            /* ⬇️⬇️⬇️ Add this ⬇️⬇️⬇️ */
-            builder.Services.AddSingleton<IOpenApiHttpTriggerAuthorization>(_ =>
-                            {
-                                var auth = new OpenApiHttpTriggerAuthorization(async req =>
-                                {
-                                    var result = default(OpenApiAuthorizationResult);
-
-                                    var authtoken = (string)req.Headers["Authorization"];
-                                    if (authtoken.IsNullOrWhiteSpace())
-                                    {
-                                        result = new OpenApiAuthorizationResult()
-                                        {
-                                            StatusCode = HttpStatusCode.Unauthorized,
-                                            ContentType = "text/plain",
-                                            Payload = "Unauthorized",
-                                        };
-
-                                        return await Task.FromResult(result).ConfigureAwait(false);
-                                    }
-
-                                    return await Task.FromResult(result).ConfigureAwait(false);
-                                });
-
-                                return auth;
                             });
             /* ⬆️⬆️⬆️ Add this ⬆️⬆️⬆️ */
         }

--- a/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.OutOfProc/Program.cs
+++ b/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.OutOfProc/Program.cs
@@ -49,26 +49,21 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.OutOfP
                                     ExcludeRequestingHost = DefaultOpenApiConfigurationOptions.IsRequestingHostExcluded(),
                                     ForceHttps = DefaultOpenApiConfigurationOptions.IsHttpsForced(),
                                     ForceHttp = DefaultOpenApiConfigurationOptions.IsHttpForced(),
+                                    Security = new OpenApiHttpTriggerAuthorization(async req =>
+                                    {
+                                        var result = default(OpenApiAuthorizationResult);
+
+                                        // ⬇️⬇️⬇️ Add your custom authorisation logic ⬇️⬇️⬇️
+                                        //
+                                        // CUSTOM AUTHORISATION LOGIC
+                                        //
+                                        // ⬆️⬆️⬆️ Add your custom authorisation logic ⬆️⬆️⬆️
+
+                                        return await Task.FromResult(result).ConfigureAwait(false);
+                                    }),
                                 };
 
                                 return options;
-                            })
-                            .AddSingleton<IOpenApiHttpTriggerAuthorization>(_ =>
-                            {
-                                var auth = new OpenApiHttpTriggerAuthorization(async req =>
-                                {
-                                    var result = default(OpenApiAuthorizationResult);
-
-                                    // ⬇️⬇️⬇️ Add your custom authorisation logic ⬇️⬇️⬇️
-                                    //
-                                    // CUSTOM AUTHORISATION LOGIC
-                                    //
-                                    // ⬆️⬆️⬆️ Add your custom authorisation logic ⬆️⬆️⬆️
-
-                                    return await Task.FromResult(result).ConfigureAwait(false);
-                                });
-
-                                return auth;
                             })
                             ;
                 })

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.InProc/Startup.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.InProc/Startup.cs
@@ -45,26 +45,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.InProc
                                     ExcludeRequestingHost = DefaultOpenApiConfigurationOptions.IsRequestingHostExcluded(),
                                     ForceHttps = DefaultOpenApiConfigurationOptions.IsHttpsForced(),
                                     ForceHttp = DefaultOpenApiConfigurationOptions.IsHttpForced(),
+                                    Security = new OpenApiHttpTriggerAuthorization(async req =>
+                                    {
+                                        var result = default(OpenApiAuthorizationResult);
+
+                                        // ⬇️⬇️⬇️ Add your custom authorisation logic ⬇️⬇️⬇️
+                                        //
+                                        // CUSTOM AUTHORISATION LOGIC
+                                        //
+                                        // ⬆️⬆️⬆️ Add your custom authorisation logic ⬆️⬆️⬆️
+
+                                        return await Task.FromResult(result).ConfigureAwait(false);
+                                    }),
                                 };
 
                                 return options;
-                            })
-                            .AddSingleton<IOpenApiHttpTriggerAuthorization>(_ =>
-                            {
-                                var auth = new OpenApiHttpTriggerAuthorization(async req =>
-                                {
-                                    var result = default(OpenApiAuthorizationResult);
-
-                                    // ⬇️⬇️⬇️ Add your custom authorisation logic ⬇️⬇️⬇️
-                                    //
-                                    // CUSTOM AUTHORISATION LOGIC
-                                    //
-                                    // ⬆️⬆️⬆️ Add your custom authorisation logic ⬆️⬆️⬆️
-
-                                    return await Task.FromResult(result).ConfigureAwait(false);
-                                });
-
-                                return auth;
                             })
                             ;
         }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/OpenApiHttpTriggerContext.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/OpenApiHttpTriggerContext.cs
@@ -36,17 +36,14 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi
         private Assembly _appAssembly;
         private IOpenApiConfigurationOptions _configOptions;
         private IOpenApiCustomUIOptions _uiOptions;
-        private IOpenApiHttpTriggerAuthorization _httpTriggerAuthorization;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OpenApiHttpTriggerContext"/> class.
         /// </summary>
         /// <param name="configOptions"><see cref="IOpenApiConfigurationOptions"/> instance.</param>
-        /// <param name="httpTriggerAuthorization"><see cref="IOpenApiHttpTriggerAuthorization"/> instance.</param>
-        public OpenApiHttpTriggerContext(IOpenApiConfigurationOptions configOptions = null, IOpenApiHttpTriggerAuthorization httpTriggerAuthorization = null)
+        public OpenApiHttpTriggerContext(IOpenApiConfigurationOptions configOptions = null)
         {
             this._configOptions = configOptions;
-            this._httpTriggerAuthorization = httpTriggerAuthorization;
 
             this.PackageAssembly = this.GetAssembly<ISwaggerUI>();
 
@@ -111,12 +108,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi
         {
             get
             {
-                if (this._httpTriggerAuthorization.IsNullOrDefault())
+                if (this.OpenApiConfigurationOptions.Security.IsNullOrDefault())
                 {
-                    this._httpTriggerAuthorization = OpenApiHttpTriggerAuthorizationResolver.Resolve(this.ApplicationAssembly);
+                    this.OpenApiConfigurationOptions.Security = OpenApiHttpTriggerAuthorizationResolver.Resolve(this.ApplicationAssembly);
                 }
 
-                return this._httpTriggerAuthorization;
+                return this.OpenApiConfigurationOptions.Security;
             }
         }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IOpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IOpenApiConfigurationOptions.cs
@@ -44,5 +44,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions
         /// Gets or sets the list of <see cref="IDocumentFilter"/> instances.
         /// </summary>
         List<IDocumentFilter> DocumentFilters { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="IOpenApiHttpTriggerAuthorization"/> instance for Swagger endpoints.
+        /// </summary>
+        IOpenApiHttpTriggerAuthorization Security { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
@@ -52,6 +52,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
         /// <inheritdoc />
         public override List<IDocumentFilter> DocumentFilters { get; set; } = new List<IDocumentFilter>();
 
+        /// <inheritdoc />
+        public override IOpenApiHttpTriggerAuthorization Security { get; set; } = new DefaultOpenApiHttpTriggerAuthorization();
+
         /// <summary>
         /// Gets the OpenAPI document version.
         /// </summary>

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiConfigurationOptions.cs
@@ -33,5 +33,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
 
         /// <inheritdoc />
         public virtual List<IDocumentFilter> DocumentFilters { get; set; } = new List<IDocumentFilter>();
+
+        /// <inheritdoc />
+        public virtual IOpenApiHttpTriggerAuthorization Security { get; set; } = new OpenApiHttpTriggerAuthorization();
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiSettings.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiSettings.cs
@@ -37,5 +37,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
 
         /// <inheritdoc />
         public List<IDocumentFilter> DocumentFilters { get; set; } = new List<IDocumentFilter>();
+
+        /// <inheritdoc />
+        public IOpenApiHttpTriggerAuthorization Security { get; set; } = new OpenApiHttpTriggerAuthorization();
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiHttpTriggerContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiHttpTriggerContext.cs
@@ -35,18 +35,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
         private string _dllpath;
         private Assembly _appAssembly;
         private IOpenApiConfigurationOptions _configOptions;
-        private IOpenApiHttpTriggerAuthorization _httpTriggerAuthorization;
         private IOpenApiCustomUIOptions _uiOptions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OpenApiHttpTriggerContext"/> class.
         /// </summary>
         /// <param name="configOptions"><see cref="IOpenApiConfigurationOptions"/> instance.</param>
-        /// <param name="httpTriggerAuthorization"><see cref="IOpenApiHttpTriggerAuthorization"/> instance.</param>
-        public OpenApiHttpTriggerContext(IOpenApiConfigurationOptions configOptions = null, IOpenApiHttpTriggerAuthorization httpTriggerAuthorization = null)
+        public OpenApiHttpTriggerContext(IOpenApiConfigurationOptions configOptions = null)
         {
             this._configOptions = configOptions;
-            this._httpTriggerAuthorization = httpTriggerAuthorization;
             this.PackageAssembly = this.GetAssembly<ISwaggerUI>();
 
             var host = HostJsonResolver.Resolve();
@@ -96,12 +93,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
         {
             get
             {
-                if (this._httpTriggerAuthorization.IsNullOrDefault())
+                if (this.OpenApiConfigurationOptions.Security.IsNullOrDefault())
                 {
-                    this._httpTriggerAuthorization = OpenApiHttpTriggerAuthorizationResolver.Resolve(this.ApplicationAssembly);
+                    this.OpenApiConfigurationOptions.Security = OpenApiHttpTriggerAuthorizationResolver.Resolve(this.ApplicationAssembly);
                 }
 
-                return this._httpTriggerAuthorization;
+                return this.OpenApiConfigurationOptions.Security;
             }
         }
 
@@ -163,7 +160,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
         /// <inheritdoc />
         public virtual async Task<OpenApiAuthorizationResult> AuthorizeAsync(IHttpRequestDataObject req)
         {
-            return await this.OpenApiHttpTriggerAuthorization.AuthorizeAsync(req).ConfigureAwait(false);    
+            return await this.OpenApiHttpTriggerAuthorization.AuthorizeAsync(req).ConfigureAwait(false);
         }
 
         /// <inheritdoc />

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/DefaultOpenApiConfigurationOptionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/DefaultOpenApiConfigurationOptionsTests.cs
@@ -282,12 +282,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
             result.Should().Be(expected);
         }
 
+        [TestMethod]
         public void Given_Type_When_Instantiated_Then_It_Should_Return_EmptyListOfDocumentFilters()
         {
             var options = new DefaultOpenApiConfigurationOptions();
 
             options.DocumentFilters.Should().NotBeNull();
             options.DocumentFilters.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void Given_Type_When_Instantiated_Then_It_Should_Return_DefaultOpenApiHttpTriggerAuthorization()
+        {
+            var options = new DefaultOpenApiConfigurationOptions();
+
+            options.Security.Should().NotBeNull();
+            options.Security.Should().BeOfType<DefaultOpenApiHttpTriggerAuthorization>();
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/OpenApiConfigurationOptionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/OpenApiConfigurationOptionsTests.cs
@@ -29,6 +29,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
 
             options.DocumentFilters.Should().NotBeNull();
             options.DocumentFilters.Should().HaveCount(0);
+
+            options.Security.Should().NotBeNull();
+            options.Security.Should().BeOfType<OpenApiHttpTriggerAuthorization>();
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/OpenApiHttpTriggerContextTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/OpenApiHttpTriggerContextTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests.Fakes;
@@ -184,7 +185,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests
         {
             var location = new FileInfo(Assembly.GetExecutingAssembly().Location).Directory.FullName;
             var req = new Mock<IHttpRequestDataObject>();
-            var context = new OpenApiHttpTriggerContext();
+
+            var res = new OpenApiAuthorizationResult()
+            {
+                StatusCode = FakeOpenApiHttpTriggerAuthorization.StatusCode,
+                ContentType = FakeOpenApiHttpTriggerAuthorization.ContentType,
+                Payload = FakeOpenApiHttpTriggerAuthorization.Payload,
+            };
+
+            var auth = new Mock<IOpenApiHttpTriggerAuthorization>();
+            auth.Setup(p => p.AuthorizeAsync(It.IsAny<IHttpRequestDataObject>())).ReturnsAsync(res);
+
+            var options = new Mock<IOpenApiConfigurationOptions>();
+            options.SetupGet(p => p.Security).Returns(auth.Object);
+
+            var context = new OpenApiHttpTriggerContext(options.Object);
 
             var result = await context.SetApplicationAssemblyAsync(location, false)
                                       .AuthorizeAsync(req.Object);


### PR DESCRIPTION
This PR is:

* To merge the existing `OpenApiHttpTriggerAuthorization` with `OpenApiConfigurationOptions` so that the number of parameters to the constructor of `OpenApiHttpTriggerContext` gets reduced.