### PR TITLE
Accept multiple content types

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Extensions/DocumentHelperExtensions.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Extensions/DocumentHelperExtensions.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Extensions
             }
 
             var contents = attributes.Where(p => p.Deprecated == false)
-                                     .Where(p => p.ContentType == "application/x-www-form-urlencoded" || p.ContentType == "multipart/form-data")
+                                     .Where(p => p.ContentTypes.Contains("application/x-www-form-urlencoded") || p.ContentTypes.Contains("multipart/form-data"))
                                      .Select(p => p.ToOpenApiMediaType(namingStrategy, collection, version));
             if (!contents.Any())
             {

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Attributes/OpenApiPayloadAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Attributes/OpenApiPayloadAttribute.cs
@@ -1,5 +1,6 @@
 using System;
-
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes
@@ -12,16 +13,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes
         /// <summary>
         /// Initializes a new instance of the <see cref="OpenApiPayloadAttribute"/> class.
         /// </summary>
-        /// <param name="contentType">Content type.</param>
+        /// <param name="contentType">Content type. This can be a comma seperated list for additional content types.</param>
         /// <param name="bodyType">Type of payload.</param>
         protected OpenApiPayloadAttribute(string contentType, Type bodyType)
         {
             this.ContentType = contentType ?? throw new ArgumentNullException(nameof(contentType));
             this.BodyType = bodyType ?? throw new ArgumentNullException(nameof(bodyType));
+
+            this.ContentTypes = new HashSet<string>(contentType.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()));
         }
 
         /// <summary>
-        /// Gets the content type.
+        /// Gets the content type. This can be a comma seperated list for additional content types.
         /// </summary>
         public virtual string ContentType { get; }
 
@@ -39,5 +42,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes
         /// Gets or sets the type of the example. It SHOULD be inheriting the <see cref="OpenApiExample{T}"/> class.
         /// </summary>
         public virtual Type Example { get; set; }
+
+        /// <summary>
+        /// Gets the content types.
+        /// </summary>
+        public virtual IEnumerable<string> ContentTypes { get; private set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Attributes/OpenApiResponseWithBodyAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Attributes/OpenApiResponseWithBodyAttribute.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes
         /// Initializes a new instance of the <see cref="OpenApiResponseWithBodyAttribute"/> class.
         /// </summary>
         /// <param name="statusCode">HTTP status code.</param>
-        /// <param name="contentType">Content type.</param>
+        /// <param name="contentType">Content type. This can be a comma seperated list for additional content types.</param>
         /// <param name="bodyType">Type of payload.</param>
         public OpenApiResponseWithBodyAttribute(HttpStatusCode statusCode, string contentType, Type bodyType)
             : base(contentType, bodyType)

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/DocumentHelper.cs
@@ -87,8 +87,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core
                 return null;
             }
 
-            var contents = attributes.Where(p => p.Deprecated == false)
-                                     .ToDictionary(p => p.ContentType, p => p.ToOpenApiMediaType(namingStrategy, collection, version));
+            var contents = new Dictionary<string, OpenApiMediaType>();
+            foreach (var attribute in attributes.Where(p => p.Deprecated == false))
+            {
+                var mediaType = attribute.ToOpenApiMediaType(namingStrategy, collection, version);
+                foreach (var contentType in attribute.ContentTypes)
+                {
+                    contents.Add(contentType, mediaType);
+                }
+            }
 
             if (contents.Any())
             {

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/DocumentHelperExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/DocumentHelperExtensions.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
             }
 
             var contents = attributes.Where(p => p.Deprecated == false)
-                                     .Where(p => p.ContentType == "application/x-www-form-urlencoded" || p.ContentType == "multipart/form-data")
+                                     .Where(p => p.ContentTypes.Contains("application/x-www-form-urlencoded") || p.ContentTypes.Contains("multipart/form-data"))
                                      .Select(p => p.ToOpenApiMediaType(namingStrategy, collection, version));
             if (!contents.Any())
             {

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiResponseWithBodyAttributeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiResponseWithBodyAttributeExtensions.cs
@@ -33,10 +33,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
                                   ? $"Payload of {attribute.BodyType.GetOpenApiDescription()}"
                                   : attribute.Description;
             var mediaType = attribute.ToOpenApiMediaType<OpenApiResponseWithBodyAttribute>(namingStrategy, collection, version);
-            var content = new Dictionary<string, OpenApiMediaType>()
-                              {
-                                  { attribute.ContentType, mediaType }
-                              };
+
+            var content = new Dictionary<string, OpenApiMediaType>();
+            foreach (var contentType in attribute.ContentTypes)
+            {
+                content.Add(contentType, mediaType);
+            }
+
             var response = new OpenApiResponse()
             {
                 Description = description,


### PR DESCRIPTION
This is a easy fix to allow the `OpenApiResponseWithBodyAttribute` to list a number of extra content types.

The rest of swagger just picks this up and shows a nice `Accept` picker
![image](https://user-images.githubusercontent.com/47455366/186170584-96c76d13-19a7-4b1e-bace-361459c26a0e.png)


Attempt at fixing #59 