### PR TITLE
Add OpenAPI document generation scripts - `.ps1` and `.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,42 @@
 <!-- * [**Integrating OpenAPI-enabled Azure Functions to Power Platform**](docs/integrate-with-powerplatform.md): This document shows how to integrate the Azure Functions application with [Power Platform](https://powerplatform.microsoft.com/?WT.mc_id=dotnet_0000_juyoo), via this OpenAPI extension. -->
 
 
+## GitHub Actions Support ##
+
+If you are using GitHub Actions as your preferred CI/CD pipeline, you can run the GitHub Action into your workflow to automatically generate the OpenAPI document. Find more details at the [Build OpenAPI](./actions/build-openapi/) action page.
+
+Alternatively, you can run either PowerShell script or bash shell script to generate the OpenAPI document within your own CI/CD pipeline other than GitHub Actions. Here are two script files:
+
+* PowerShell: [Get-OpenApiDocument.ps1](./actions/Get-OpenApiDocument.ps1)
+
+    ```powershell
+    ./actions/Get-OpenApiDocument.ps1 `
+        -FunctionAppPath    <function app directory> `
+        -BaseUri            <function app base URI> `
+        -Endpoint           <endpoint for OpenAPI document> `
+        -OutputPath         <output directory for generated OpenAPI document> `
+        -OutputFilename     <OpenAPI document name> `
+        -Delay              <delay in second between run function app and document generation> `
+        -UseWindows         <switch indicating whether to use Windows OS or not>
+    ```
+
+    For more details, run `Get-OpenApiDocument.ps1 -Help`
+
+* Bash shell: [get-openapi-document.sh](./actions/get-openapi-document.sh)
+
+    ```bash
+    ./actions/get-openapi-document.sh \
+        -p|--functionapp-path   <function app directory> \
+        -u|--base-uri           <function app base URI> \
+        -e|--endpoint           <endpoint for OpenAPI document> \
+        -o|--output-path        <output directory for generated OpenAPI document> \
+        -f|--output-filename    <OpenAPI document name> \
+        -d|--delay              <delay in second between run function app and document generation>
+    ```
+
+    For more details, run `get-openapi-document.sh --help`
+
+
 ## Sample Azure Function Apps with OpenAPI Document Enabled ##
 
 Here are sample apps using the project references:

--- a/actions/Get-OpenApiDocument.ps1
+++ b/actions/Get-OpenApiDocument.ps1
@@ -40,7 +40,7 @@ function Show-Usage {
             [-FunctionAppPath <function app directory>] ``
             [-BaseUri <function app base URI>] ``
             [-Endpoint <endpoint for OpenAPI document>] ``
-            [-OutputPath <output directory for generated OpenAPI document> ``
+            [-OutputPath <output directory for generated OpenAPI document>] ``
             [-OutputFilename <OpenAPI document name>] ``
             [-Delay <delay in second between run function app and document generation>] ``
             [-UseWindows] ``

--- a/actions/Get-OpenApiDocument.ps1
+++ b/actions/Get-OpenApiDocument.ps1
@@ -1,0 +1,103 @@
+### Gets the OpenAPI document from the locally running Functions app.
+Param(
+    [string]
+    [Parameter(Mandatory=$false)]
+    $FunctionAppPath = "bin/Debug/net6.0",
+
+    [string]
+    [Parameter(Mandatory=$false)]
+    $BaseUri = "http://localhost:7071/api/",
+
+    [string]
+    [Parameter(Mandatory=$false)]
+    [ValidateSet("swagger.json", "openapi/v2.json", "openapi/v3.json", "swagger.yaml", "openapi/v2.yaml", "openapi/v3.yaml")]
+    $Endpoint = "swagger.json",
+
+    [string]
+    [Parameter(Mandatory=$false)]
+    $OutputPath = "generated",
+
+    [string]
+    [Parameter(Mandatory=$false)]
+    $OutputFilename = "swagger.json",
+
+    [int]
+    [Parameter(Mandatory=$false)]
+    $Delay = 30,
+
+    [switch]
+    [Parameter(Mandatory=$false)]
+    $UseWindows,
+
+    [switch]
+    [Parameter(Mandatory=$false)]
+    $Help
+)
+
+function Show-Usage {
+    Write-Output "    This downloads the OpenAPI document from the locally running Azure Functions app.
+    Usage: $(Split-Path $MyInvocation.ScriptName -Leaf) ``
+            [-FunctionAppPath <function app directory>] ``
+            [-BaseUri <function app base URI>] ``
+            [-Endpoint <endpoint for OpenAPI document>] ``
+            [-OutputPath <output directory for generated OpenAPI document> ``
+            [-OutputFilename <OpenAPI document name>] ``
+            [-Delay <delay in second between run function app and document generation>] ``
+            [-UseWindows] ``
+            [-Help]
+    Options:
+        -FunctionAppPath    Function app path. It can be the project directory or compiled app directory.
+                            Default: 'bin/Debug/net6.0'
+        -BaseUri            Function app base URI.
+                            Default: 'http://localhost:7071/api/'
+        -Endpoint           OpenAPI document endpoint.
+                            Default: 'swagger.json'
+        -OutputPath         Output directory to store the generated OpenAPI document.
+                            Default: 'generated'
+        -OutputFilename     Output filename for the generated OpenAPI document.
+                            Default: 'swagger.json'
+        -Delay              Delay in second between the function app run and document generation.
+                            Default: 30
+        -UseWindows         Switch that indicates using Windows OS.
+        -Help               Show this message.
+"
+
+    Exit 0
+}
+
+# Show usage
+$needHelp = $Help -eq $true
+if ($needHelp -eq $true) {
+    Show-Usage
+    Exit 0
+}
+
+# Check the function app execution path
+$func = $(Get-Command func).Source
+if ($UseWindows -eq $true) {
+    $func = $func.Replace(".ps1", ".cmd")
+}
+
+pushd $FunctionAppPath
+
+# Run the function app in the background
+Start-Process -NoNewWindow "$func" @("start","--verbose","false")
+Start-Sleep -s $Delay
+
+$requestUri = "$($BaseUri.TrimEnd('/'))/$($Endpoint.TrimStart('/'))"
+$filepath = "$($OutputPath.TrimEnd('/'))/$($OutputFilename.TrimStart('/'))"
+
+if ($(Test-Path -Path "$($OutputPath.TrimEnd('/'))" -PathType Container) -eq $false) {
+    New-Item -Path "$($OutputPath.TrimEnd('/'))" -ItemType Directory
+}
+
+# Download the OpenAPI document
+Invoke-RestMethod -Method Get -Uri $requestUri | ConvertTo-Json -Depth 100 | Out-File -FilePath $filepath -Force
+
+# Stop the function app
+$process = $(get-Process -Name func)
+if ($process -ne $null) {
+    Stop-Process -Id $process.Id
+}
+
+popd

--- a/actions/get-openapi-document.sh
+++ b/actions/get-openapi-document.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+set -e
+
+function usage() {
+    cat <<USAGE
+    Usage: $0 <options>
+    Options:
+        [-p|--functionapp-path] Function app path. It can be the project directory or compiled app directory.
+                                Default: 'bin/Debug/net6.0'
+        [-u|--base-uri]         Base URI of the function app.
+                                Default: 'http://localhost:7071/api/'
+        [-e|--endpoint]         OpenAPI document endpoint.
+                                Default: 'swagger.json'
+        [-o|--output-path]      Output directory to store the generated OpenAPI document.
+                                Default: 'generated'
+        [-f|--output-filename]  Output filename for the generated OpenAPI document.
+                                Default: 'swagger.json'
+        [-d|--delay]            Delay in second between the function app run and document generation.
+                                Default: 30
+        [-h|--help]             Show this message.
+USAGE
+
+    exit 1
+}
+
+functionapp_path="bin/Debug/net6.0"
+base_uri="http://localhost:7071/api/"
+endpoint="swagger.json"
+output_path="generated"
+output_filename="swagger.json"
+delay=30
+
+if [[ $# -eq 0 ]]; then
+    functionapp_path="bin/Debug/net6.0"
+    base_uri="http://localhost:7071/api/"
+    endpoint="swagger.json"
+    output_path="generated"
+    output_filename="swagger.json"
+    delay=30
+fi
+
+while [[ "$1" != "" ]]; do
+    case $1 in
+    -p | --functionapp-path)
+        shift
+        functionapp_path=$1
+        ;;
+
+    -u | --base-uri)
+        shift
+        base_uri=$1
+        ;;
+
+    -e | --endpoint)
+        shift
+        endpoint=$1
+        ;;
+
+    -o | --output-path)
+        shift
+        output_path=$1
+        ;;
+
+    -f | --output-filename)
+        shift
+        output_filename=$1
+        ;;
+
+    -d | --delay)
+        shift
+        delay=$1
+        ;;
+
+    -h | --help)
+        usage
+        exit 1
+        ;;
+
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+
+    shift
+done
+
+pushd $functionapp_path
+
+# Run the function app in the background
+func start --verbose false &
+
+sleep $delay
+
+request_uri="$(echo "$base_uri" | sed 's:/*$::')/$(echo "$endpoint" | sed 's:^/*::')"
+filepath="$(echo "$output_path" | sed 's:/*$::')/$(echo "$output_filename" | sed 's:^/*::')"
+
+if [ ! -d "$output_path" ]; then
+    mkdir "$output_path"
+fi
+
+# Download the OpenAPI document
+curl $request_uri > $filepath
+
+# Stop the function app
+PID=`ps -eaf | grep func | grep -v grep | awk '{print $2}'`
+if [[ "" !=  "$PID" ]]; then
+  kill -9 $PID
+fi
+
+popd

--- a/actions/get-openapi-document.sh
+++ b/actions/get-openapi-document.sh
@@ -104,9 +104,9 @@ fi
 curl $request_uri > $filepath
 
 # Stop the function app
-PID=`ps -eaf | grep func | grep -v grep | awk '{print $2}'`
+PID=$(lsof -nP -i4TCP:7071 | grep LISTEN | awk '{print $2}')
 if [[ "" !=  "$PID" ]]; then
-  kill -9 $PID
+    kill -9 $PID
 fi
 
 popd


### PR DESCRIPTION
Related to #489 

To extend the GitHub Actions capability to other CI/CD pipelines, like Azure DevOps, this PR is to provide both PowerShell script and Bash shell script for developers to choose.

