### PR TITLE
Fix issue with DocumentHelperExceptions.GetOpenApiParameters not forwarding the OpenAPI schema version.

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Extensions/DocumentHelperExtensions.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Extensions/DocumentHelperExtensions.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Extensions
         {
             var parameters = element.GetCustomAttributes<OpenApiParameterAttribute>(inherit: false)
                                     .Where(p => p.Deprecated == false)
-                                    .Select(p => p.ToOpenApiParameter(namingStrategy, collection))
+                                    .Select(p => p.ToOpenApiParameter(namingStrategy, collection, version))
                                     .ToList();
 
             // This is the interim solution to resolve:

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/DocumentHelperExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/DocumentHelperExtensions.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
         {
             var parameters = element.GetCustomAttributes<OpenApiParameterAttribute>(inherit: false)
                                     .Where(p => p.Deprecated == false)
-                                    .Select(p => p.ToOpenApiParameter(namingStrategy, collection))
+                                    .Select(p => p.ToOpenApiParameter(namingStrategy, collection, version))
                                     .ToList();
 
             // This is the interim solution to resolve:

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/OpenApiParameterAttributeExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/OpenApiParameterAttributeExtensionsTests.cs
@@ -225,5 +225,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
 
             result.Deprecated.Should().Be(deprecated.GetValueOrDefault());
         }
+
+        [TestMethod]
+        public void Given_Value_With_Examples_When_ToOpenApiParameter_Invoked_With_OpenApi_V3_Then_It_Should_Return_Result()
+        {
+            var attribute = new OpenApiParameterAttribute("hello")
+            {
+                Type = typeof(string),
+                Summary = "lorem ipsum",
+                Description = "hello world",
+                Required = true,
+                Example = typeof(FakeStringParameterExample),
+                In = ParameterLocation.Path,
+            };
+
+            var result = OpenApiParameterAttributeExtensions.ToOpenApiParameter(attribute, version: OpenApiVersionType.V3);
+
+            result.Example.Should().BeNull();
+        }
+
     }
 }


### PR DESCRIPTION
When generating an OpenAPI v3 Schema with [OpenApiParameter(Example = ...)], the generated schema includes the following, which does not quite validate successfully.

```
example: 1
examples:
 - 1
```

To quote the OpenAPI Schema 3.0.1 specification: `The example field is mutually exclusive of the examples field.`