### PR TITLE
Fix handling of [JsonIgnore] to recurse and apply to inherited properties

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiSchemaExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiSchemaExtensions.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
             var allProperties = type.IsInterface
                                     ? new[] { type }.Concat(type.GetInterfaces()).SelectMany(i => i.GetProperties())
                                     : type.GetProperties();
-            var properties = allProperties.Where(p => !p.ExistsCustomAttribute<JsonIgnoreAttribute>());
+            var properties = allProperties.Where(p => !p.ExistsCustomAttribute<JsonIgnoreAttribute>(true));
 
             var retVal = new Dictionary<string, OpenApiSchema>();
             foreach (var property in properties)

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
@@ -634,7 +634,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
         public static bool HasRecursiveProperty(this Type type)
         {
             var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                                 .Where(p => !p.ExistsCustomAttribute<JsonIgnoreAttribute>());
+                                 .Where(p => !p.ExistsCustomAttribute<JsonIgnoreAttribute>(true));
 
             var hasRecursiveType = properties.Select(p => p.PropertyType)
                                              .Any(p => p == type);

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
             // Processes properties.
             var properties = type.Value
                                  .GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                                 .Where(p => !p.ExistsCustomAttribute<JsonIgnoreAttribute>())
+                                 .Where(p => !p.ExistsCustomAttribute<JsonIgnoreAttribute>(true))
                                  .ToDictionary(p => p.GetJsonPropertyName(namingStrategy), p => p);
 
             this.ProcessProperties(instance, name, properties, namingStrategy);

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/RecursiveObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/RecursiveObjectTypeVisitor.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
             // Processes non-recursive properties
             var properties = type.Value
                                  .GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                                 .Where(p => !p.ExistsCustomAttribute<JsonIgnoreAttribute>())
+                                 .Where(p => !p.ExistsCustomAttribute<JsonIgnoreAttribute>(true))
                                  .Where(p => p.PropertyType != type.Value)
                                  .ToDictionary(p => p.GetJsonPropertyName(namingStrategy), p => p);
 
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
             // Processes recursive properties
             var recursiveProperties = type.Value
                                           .GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                                          .Where(p => !p.ExistsCustomAttribute<JsonIgnoreAttribute>())
+                                          .Where(p => !p.ExistsCustomAttribute<JsonIgnoreAttribute>(true))
                                           .Where(p => p.PropertyType == type.Value)
                                           .ToDictionary(p => p.GetJsonPropertyName(namingStrategy), p => p);
             var recursiveSchemas = recursiveProperties.ToDictionary(p => p.Key,


### PR DESCRIPTION
Fix the handling of the Newtonsoft JsonIgnore attribute to take into account of inheritance.
