### PR TITLE
add TimeSpanObjectTypeVisitor

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/EnumExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/EnumExtensions.cs
@@ -165,6 +165,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
                     {
                         return "date-time";
                     }
+                    else if (type == typeof(TimeSpan))
+                    {
+                        return "timespan";
+                    }
                     else
                     {
                         return null;

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/EnumExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/EnumExtensions.cs
@@ -88,6 +88,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
                     {
                         return "string";
                     }
+                    else if (type == typeof(TimeSpan))
+                    {
+                        return "string";
+                    }
                     else
                     {
                         return "object";

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
                 case TypeCode.DateTime:
                 case TypeCode.String:
                 case TypeCode.Object when type == typeof(Guid):
+                case TypeCode.Object when type == typeof(TimeSpan):
                 case TypeCode.Object when type == typeof(DateTime):
                 case TypeCode.Object when type == typeof(DateTimeOffset):
                     return true;
@@ -85,6 +86,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
             typeof(Guid),
             typeof(DateTime),
             typeof(DateTimeOffset),
+            typeof(TimeSpan),
             typeof(Uri),
             typeof(object),
         };

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
         {
             typeof(Guid),
             typeof(DateTime),
+            typeof(TimeSpan),
             typeof(DateTimeOffset),
             typeof(Uri),
             typeof(Type),

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/RecursiveObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/RecursiveObjectTypeVisitor.cs
@@ -45,6 +45,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
             {
                 isVisitable = false;
             }
+            else if (type == typeof(TimeSpan))
+            {
+                isVisitable = false;
+            }
             else if (type == typeof(DateTimeOffset))
             {
                 isVisitable = false;

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/TimeSpanObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/TimeSpanObjectTypeVisitor.cs
@@ -1,0 +1,50 @@
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.OpenApi.Models;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
+{
+    public class TimeSpanObjectTypeVisitor : TypeVisitor
+    {
+        public TimeSpanObjectTypeVisitor(VisitorCollection visitorCollection) : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
+        public override OpenApiSchema ParameterVisit(Type type, NamingStrategy namingStrategy)
+        {
+            return this.ParameterVisit(dataType: "string", dataFormat: "timespan");
+        }
+
+        /// <inheritdoc />
+        public override bool IsVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type, TypeCode.Object) && type == typeof(TimeSpan);
+
+            return isVisitable;
+        }
+
+        /// <inheritdoc />
+        public override void Visit(IAcceptor acceptor, KeyValuePair<string, Type> type, NamingStrategy namingStrategy, params Attribute[] attributes)
+        {
+            this.Visit(acceptor, name: type.Key, title: null, dataType: "string", dataFormat: "timespan", attributes: attributes);
+        }
+
+        /// <inheritdoc />
+        public override bool IsPayloadVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type);
+
+            return isVisitable;
+        }
+
+        /// <inheritdoc />
+        public override OpenApiSchema PayloadVisit(Type type, NamingStrategy namingStrategy)
+        {
+            return this.PayloadVisit(dataType: "string", dataFormat: "timespan");
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/TimeSpanObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/TimeSpanObjectTypeVisitor.cs
@@ -3,12 +3,15 @@ using Microsoft.OpenApi.Models;
 using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
 {
+    /// <summary>
+    /// This represents the type visitor for <see cref="TimeSpan"/>.
+    /// </summary>
     public class TimeSpanObjectTypeVisitor : TypeVisitor
     {
+        /// <inheritdoc />
         public TimeSpanObjectTypeVisitor(VisitorCollection visitorCollection) : base(visitorCollection)
         {
         }
@@ -17,6 +20,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
         public override OpenApiSchema ParameterVisit(Type type, NamingStrategy namingStrategy)
         {
             return this.ParameterVisit(dataType: "string", dataFormat: "timespan");
+        }
+
+        /// <inheritdoc />
+        public override bool IsParameterVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type, TypeCode.Object) && type == typeof(TimeSpan);
+
+            return isVisitable;
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/TypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/TypeVisitor.cs
@@ -238,6 +238,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
                 return new OpenApiDateTime((DateTime) @default);
             }
 
+            if (@default is TimeSpan)
+            {
+                return new OpenApiString(@default.ToString());
+            }
+
             if (@default is DateTimeOffset)
             {
                 return new OpenApiDateTime((DateTimeOffset) @default);

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes/FakeTimeSpanParameterExample.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes/FakeTimeSpanParameterExample.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Resolvers;
+using Newtonsoft.Json.Serialization;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes
+{
+    public class FakeTimeSpanParameterExample : OpenApiExample<TimeSpan>
+    {
+        public override IOpenApiExample<TimeSpan> Build(NamingStrategy namingStrategy = null)
+        {
+            this.Examples.Add(OpenApiExampleResolver.Resolve("timeSpanValue1", new TimeSpan(6,12,14).ToString(), namingStrategy));
+            this.Examples.Add(OpenApiExampleResolver.Resolve("timeSpanValue2", new TimeSpan(6,12,14,45).ToString(), namingStrategy));
+            return this;
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Abstractions/OpenApiExampleTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Abstractions/OpenApiExampleTests.cs
@@ -180,6 +180,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Abstractions
         }
 
         [TestMethod]
+        [DataRow("timeSpanValue1","06:12:14")]
+        [DataRow("timeSpanValue2", "6.12:14:45")]
+        public void Given_TimeSpanType_When_Instantiated_Then_It_Should_Return_Result(string exampleName, string exampleValue)
+        {
+            var namingStrategy = new DefaultNamingStrategy();
+            var example = new FakeTimeSpanParameterExample();
+
+            var result = example.Build(namingStrategy).Examples;
+
+            result[exampleName].Value.Should().BeOfType<OpenApiString>();
+            (result[exampleName].Value as OpenApiString).Value.Should().Be(exampleValue);
+        }
+
+        [TestMethod]
         [DataRow("guidValue1", "74be27de-1e4e-49d9-b579-fe0b331d3642")]
         public void Given_GuidType_When_Instantiated_Then_It_Should_Return_Result(string exampleName, string exampleValue)
         {

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/EnumExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/EnumExtensionsTests.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
         [DataRow(typeof(DateTime), "string")]
         [DataRow(typeof(DateTimeOffset), "string")]
         [DataRow(typeof(Guid), "string")]
+        [DataRow(typeof(TimeSpan), "string")]
         [DataRow(typeof(object), "object")]
         public void Given_TypeCode_ToDataType_Should_Return_Value(Type type, string expected)
         {
@@ -69,6 +70,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
         [DataRow(typeof(DateTime), "date-time")]
         [DataRow(typeof(DateTimeOffset), "date-time")]
         [DataRow(typeof(Guid), "uuid")]
+        [DataRow(typeof(TimeSpan), "timespan")]
         [DataRow(typeof(object), null)]
         public void Given_TypeCode_ToDataFormat_Should_Return_Value(Type type, string expected)
         {

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/TypeExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/TypeExtensionsTests.cs
@@ -107,6 +107,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
         [DataRow(typeof(int?), typeof(int))]
         [DataRow(typeof(bool?), typeof(bool))]
         [DataRow(typeof(DateTime?), typeof(DateTime))]
+        [DataRow(typeof(TimeSpan?), typeof(TimeSpan))]
         public void Given_NullableType_When_GetUnderlyingType_Invoked_Then_It_Should_Return_Result(Type type, Type expected)
         {
             var result = TypeExtensions.GetUnderlyingType(type);
@@ -129,6 +130,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
         [DataRow(typeof(List<int?>), typeof(int))]
         [DataRow(typeof(List<bool?>), typeof(bool))]
         [DataRow(typeof(List<DateTime?>), typeof(DateTime))]
+        [DataRow(typeof(List<TimeSpan?>), typeof(TimeSpan))]
         public void Given_NullableListType_When_GetUnderlyingType_Invoked_Then_It_Should_Return_Result(Type type, Type expected)
         {
             var result = TypeExtensions.GetUnderlyingType(type);
@@ -151,6 +153,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
         [DataRow(typeof(Dictionary<string, int?>), typeof(int))]
         [DataRow(typeof(Dictionary<string, bool?>), typeof(bool))]
         [DataRow(typeof(Dictionary<string, DateTime?>), typeof(DateTime))]
+        [DataRow(typeof(Dictionary<string, TimeSpan?>), typeof(TimeSpan))]
         public void Given_NullableDictionaryType_When_GetUnderlyingType_Invoked_Then_It_Should_Return_Result(Type type, Type expected)
         {
             var result = TypeExtensions.GetUnderlyingType(type);

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/TimeSpanObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/TimeSpanObjectTypeVisitorTests.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+using FluentAssertions;
+
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors;
+using Microsoft.OpenApi.Any;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Newtonsoft.Json.Serialization;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors;
+
+[TestClass]
+public class TimeSpanObjectTypeVisitorTests
+{
+    private VisitorCollection _visitorCollection;
+    private IVisitor _visitor;
+    private NamingStrategy _strategy;
+
+    [TestInitialize]
+    public void Init()
+    {
+        this._visitorCollection = new VisitorCollection();
+        this._visitor = new TimeSpanObjectTypeVisitor(this._visitorCollection);
+        this._strategy = new CamelCaseNamingStrategy();
+    }
+
+    [DataTestMethod]
+    [DataRow(typeof(TimeSpan), false)]
+    public void Given_Type_When_IsNavigatable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
+    {
+        var result = this._visitor.IsNavigatable(type);
+
+        result.Should().Be(expected);
+    }
+
+    [DataTestMethod]
+    [DataRow(typeof(TimeSpan), true)]
+    public void Given_Type_When_IsVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
+    {
+        var result = this._visitor.IsVisitable(type);
+
+        result.Should().Be(expected);
+    }
+
+    [DataTestMethod]
+    [DataRow(typeof(TimeSpan), true)]
+    public void Given_Type_When_IsPayloadVisitable_Invoked_Then_It_Should_Return_Result(Type type, bool expected)
+    {
+        var result = this._visitor.IsPayloadVisitable(type);
+
+        result.Should().Be(expected);
+    }
+
+    [DataTestMethod]
+    [DataRow("string", "timespan")]
+    public void Given_Type_When_Visit_Invoked_Then_It_Should_Return_Result(string dataType, string dataFormat)
+    {
+        var name = "hello";
+        var acceptor = new OpenApiSchemaAcceptor();
+        var type = new KeyValuePair<string, Type>(name, typeof(TimeSpan));
+
+        this._visitor.Visit(acceptor, type, this._strategy);
+
+        acceptor.Schemas.Should().ContainKey(name);
+        acceptor.Schemas[name].Type.Should().Be(dataType);
+        acceptor.Schemas[name].Format.Should().Be(dataFormat);
+    }
+
+    [DataTestMethod]
+    [DataRow("hello", "lorem ipsum")]
+    public void Given_OpenApiPropertyAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, string description)
+    {
+        var acceptor = new OpenApiSchemaAcceptor();
+        var type = new KeyValuePair<string, Type>(name, typeof(TimeSpan));
+        var attribute = new OpenApiPropertyAttribute() { Description = description };
+
+        this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+        acceptor.Schemas[name].Nullable.Should().Be(false);
+        acceptor.Schemas[name].Default.Should().BeNull();
+        acceptor.Schemas[name].Description.Should().Be(description);
+    }
+
+    [DataTestMethod]
+    [DataRow("hello", true, "lorem ipsum")]
+    [DataRow("hello", false, "lorem ipsum")]
+    public void Given_OpenApiPropertyAttribute_With_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+    {
+        var @default = DateTime.UtcNow;
+        var acceptor = new OpenApiSchemaAcceptor();
+        var type = new KeyValuePair<string, Type>(name, typeof(TimeSpan));
+        var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Default = @default, Description = description };
+
+        this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+        acceptor.Schemas[name].Nullable.Should().Be(nullable);
+        acceptor.Schemas[name].Default.Should().NotBeNull();
+        (acceptor.Schemas[name].Default as OpenApiDateTime).Value.Should().Be(@default);
+        acceptor.Schemas[name].Description.Should().Be(description);
+    }
+
+    [DataTestMethod]
+    [DataRow("hello", true, "lorem ipsum")]
+    [DataRow("hello", false, "lorem ipsum")]
+    public void Given_OpenApiPropertyAttribute_Without_Default_When_Visit_Invoked_Then_It_Should_Return_Result(string name, bool nullable, string description)
+    {
+        var acceptor = new OpenApiSchemaAcceptor();
+        var type = new KeyValuePair<string, Type>(name, typeof(TimeSpan));
+        var attribute = new OpenApiPropertyAttribute() { Nullable = nullable, Description = description };
+
+        this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+        acceptor.Schemas[name].Nullable.Should().Be(nullable);
+        acceptor.Schemas[name].Default.Should().BeNull();
+        acceptor.Schemas[name].Description.Should().Be(description);
+    }
+
+    [DataTestMethod]
+    [DataRow("hello", OpenApiVisibilityType.Advanced)]
+    [DataRow("hello", OpenApiVisibilityType.Important)]
+    [DataRow("hello", OpenApiVisibilityType.Internal)]
+    public void Given_OpenApiSchemaVisibilityAttribute_When_Visit_Invoked_Then_It_Should_Return_Result(string name, OpenApiVisibilityType visibility)
+    {
+        var acceptor = new OpenApiSchemaAcceptor();
+        var type = new KeyValuePair<string, Type>(name, typeof(TimeSpan));
+        var attribute = new OpenApiSchemaVisibilityAttribute(visibility);
+
+        this._visitor.Visit(acceptor, type, this._strategy, attribute);
+
+        acceptor.Schemas[name].Extensions.Should().ContainKey("x-ms-visibility");
+        acceptor.Schemas[name].Extensions["x-ms-visibility"].Should().BeOfType<OpenApiString>();
+        (acceptor.Schemas[name].Extensions["x-ms-visibility"] as OpenApiString).Value.Should().Be(visibility.ToDisplayName(this._strategy));
+    }
+
+    [DataTestMethod]
+    [DataRow("string", "timespan")]
+    public void Given_Type_When_ParameterVisit_Invoked_Then_It_Should_Return_Result(string dataType, string dataFormat)
+    {
+        var result = this._visitor.ParameterVisit(typeof(TimeSpan), this._strategy);
+
+        result.Type.Should().Be(dataType);
+        result.Format.Should().Be(dataFormat);
+    }
+
+    [DataTestMethod]
+    [DataRow("string", "timespan")]
+    public void Given_Type_When_PayloadVisit_Invoked_Then_It_Should_Return_Null(string dataType, string dataFormat)
+    {
+        var result = this._visitor.PayloadVisit(typeof(TimeSpan), this._strategy);
+
+        result.Type.Should().Be(dataType);
+        result.Format.Should().Be(dataFormat);
+    }
+}


### PR DESCRIPTION
As reported in #401 the type of TimeSpan is incorrectly displayed as a complex object. This PR aims for fixing this issue. 

We can then have a new property in our Order class of the type TimeSpan
![image](https://user-images.githubusercontent.com/73258913/208713478-3e0f4af3-8b37-4f2d-8276-b8aed5a39e72.png)

And achieve the following result
![image](https://user-images.githubusercontent.com/73258913/208713006-0c52bc03-aa43-484b-82ee-fa6fba4517b9.png)
