### PR TITLE
Add built-in OpenAPI app settings object

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Configurations/OpenApiAuthLevelSettings.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Configurations/OpenApiAuthLevelSettings.cs
@@ -1,0 +1,18 @@
+namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Configurations
+{
+    /// <summary>
+    /// This represents the environment variable settings entity for OpenAPI document auth level.
+    /// </summary>
+    public class OpenApiAuthLevelSettings
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="AuthorizationLevel"/> value for OpenAPI document rendering endpoints.
+        /// </summary>
+        public virtual AuthorizationLevel? Document { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="AuthorizationLevel"/> value for Swagger UI page rendering endpoints.
+        /// </summary>
+        public virtual AuthorizationLevel? UI { get; set; }
+    }
+}

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Configurations/OpenApiSettings.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Configurations/OpenApiSettings.cs
@@ -1,6 +1,6 @@
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 
-namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations
+namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Configurations
 {
     /// <summary>
     /// This represents the environment variable settings entity for OpenAPI document.

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/HttpRequestObject.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/HttpRequestObject.cs
@@ -1,5 +1,7 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Claims;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Extensions;
@@ -29,6 +31,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi
 
             this.Headers = req.Headers();
             this.Query = req.Queries();
+            this.Identities = req.Identities;
             this.Body = req.Body;
         }
 
@@ -42,9 +45,13 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi
         public virtual IHeaderDictionary Headers { get; }
 
         /// <inheritdoc/>
-        public virtual IQueryCollection Query { get;}
+        public virtual IQueryCollection Query { get; }
 
         /// <inheritdoc/>
-        public virtual Stream Body { get;}
+        /// <remarks>This property has implementation but will appear on the interface from v2.0.0.</remarks>
+        public virtual IEnumerable<ClaimsIdentity> Identities { get; }
+
+        /// <inheritdoc/>
+        public virtual Stream Body { get; }
     }
 }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/OpenApiWorkerStartup.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/OpenApiWorkerStartup.cs
@@ -1,6 +1,9 @@
 using Microsoft.Azure.Functions.Worker.Core;
 using Microsoft.Azure.Functions.Worker.Extensions.OpenApi;
+using Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Configurations;
 using Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Functions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Extensions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Resolvers;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -16,6 +19,10 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi
         /// <inheritdoc />
         public override void Configure(IFunctionsWorkerApplicationBuilder applicationBuilder)
         {
+            var config = ConfigurationResolver.Resolve();
+            var settings = config.Get<OpenApiSettings>(OpenApiSettings.Name);
+
+            applicationBuilder.Services.AddSingleton(settings);
             applicationBuilder.Services.AddSingleton<IOpenApiHttpTriggerContext, OpenApiHttpTriggerContext>();
             applicationBuilder.Services.AddSingleton<IOpenApiTriggerFunction, OpenApiTriggerFunction>();
             //applicationBuilder.Services.AddSingleton<DefaultOpenApiHttpTrigger, DefaultOpenApiHttpTrigger>();

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IHttpRequestDataObject.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IHttpRequestDataObject.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.IO;
+using System.Security.Claims;
 
 using Microsoft.AspNetCore.Http;
 
@@ -30,8 +32,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions
         IQueryCollection Query { get; }
 
         /// <summary>
+        /// Gets the list of <see cref="ClaimsIdentity"/>
+        /// </summary>
+        /// <remarks>This will be added to v2.0.0</remarks>
+        //IEnumerable<ClaimsIdentity> Identities { get; }
+
+        /// <summary>
         /// Gets the request payload stream.
         /// </summary>
-        Stream Body { get;}
+        Stream Body { get; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/HttpRequestObject.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/HttpRequestObject.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.IO;
+using System.Security.Claims;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
@@ -23,6 +25,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
             this.Host = req.Host;
             this.Headers = req.Headers;
             this.Query = req.Query;
+            this.Identities = req.HttpContext.User.Identities;
             this.Body = req.Body;
         }
 
@@ -36,9 +39,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
         public virtual IHeaderDictionary Headers { get; }
 
         /// <inheritdoc/>
-        public virtual IQueryCollection Query { get;}
+        public virtual IQueryCollection Query { get; }
 
         /// <inheritdoc/>
-        public virtual Stream Body { get;}
+        /// <remarks>This property has implementation but will appear on the interface from v2.0.0.</remarks>
+        public virtual IEnumerable<ClaimsIdentity> Identities { get; }
+
+        /// <inheritdoc/>
+        public virtual Stream Body { get; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiWebJobsStartup.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiWebJobsStartup.cs
@@ -17,13 +17,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
     /// </summary>
     public class OpenApiWebJobsStartup : IWebJobsStartup
     {
-        private const string OpenApiSettingsKey = "OpenApi";
-
         /// <inheritdoc />
         public void Configure(IWebJobsBuilder builder)
         {
             var config = ConfigurationResolver.Resolve();
-            var settings = config.Get<OpenApiSettings>(OpenApiSettingsKey);
+            var settings = config.Get<OpenApiSettings>(OpenApiSettings.Name);
 
             builder.Services.AddSingleton(settings);
             builder.Services.AddSingleton<IFunctionProvider, OpenApiTriggerFunctionProvider>();

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/Configurations/OpenApiSettingsTests.cs
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/Configurations/OpenApiSettingsTests.cs
@@ -1,0 +1,241 @@
+using System;
+
+using FluentAssertions;
+
+using Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Configurations;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Extensions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Resolvers;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.Extensions.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Configurations
+{
+    [TestClass]
+    public class OpenApiSettingsTests
+    {
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Environment.SetEnvironmentVariable("OpenApi__Version", null);
+            Environment.SetEnvironmentVariable("OpenApi__DocVersion", null);
+            Environment.SetEnvironmentVariable("OpenApi__DocTitle", null);
+            Environment.SetEnvironmentVariable("OpenApi__DocDescription", null);
+            Environment.SetEnvironmentVariable("OpenApi__HostNames", null);
+            Environment.SetEnvironmentVariable("OpenApi__ForceHttps", null);
+            Environment.SetEnvironmentVariable("OpenApi__ForceHttp", null);
+            Environment.SetEnvironmentVariable("OpenApi__HideSwaggerUI", null);
+            Environment.SetEnvironmentVariable("OpenApi__HideDocument", null);
+            Environment.SetEnvironmentVariable("OpenApi__ApiKey", null);
+            Environment.SetEnvironmentVariable("OpenApi__AuthLevel__Document", null);
+            Environment.SetEnvironmentVariable("OpenApi__AuthLevel__UI", null);
+            Environment.SetEnvironmentVariable("OpenApi__BackendProxyUrl", null);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, OpenApiVersionType.V2)]
+        [DataRow("", OpenApiVersionType.V2)]
+        [DataRow("v2", OpenApiVersionType.V2)]
+        [DataRow("v3", OpenApiVersionType.V3)]
+        public void Given_Version_When_Instantiated_Then_It_Should_Return_Result(string version, OpenApiVersionType expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__Version", version);
+
+            var config = ConfigurationResolver.Resolve();
+            var settings = config.Get<OpenApiSettings>("OpenApi");
+
+            settings.Version.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, null)]
+        [DataRow("", null)]
+        [DataRow("1.0.0", "1.0.0")]
+        public void Given_DocVersion_When_Instantiated_Then_It_Should_Return_Result(string version, string expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__DocVersion", version);
+
+            var config = ConfigurationResolver.Resolve();
+            var settings = config.Get<OpenApiSettings>("OpenApi");
+
+            settings.DocVersion.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, null)]
+        [DataRow("", null)]
+        [DataRow("hello", "hello")]
+        public void Given_DocTitle_When_Instantiated_Then_It_Should_Return_Result(string title, string expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__DocTitle", title);
+
+            var config = ConfigurationResolver.Resolve();
+            var settings = config.Get<OpenApiSettings>("OpenApi");
+
+            settings.DocTitle.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, null)]
+        [DataRow("", null)]
+        [DataRow("world", "world")]
+        public void Given_DocDescription_When_Instantiated_Then_It_Should_Return_Result(string description, string expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__DocDescription", description);
+
+            var config = ConfigurationResolver.Resolve();
+            var settings = config.Get<OpenApiSettings>("OpenApi");
+
+            settings.DocDescription.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, null)]
+        [DataRow("", null)]
+        [DataRow("https://contoso", "https://contoso")]
+        [DataRow("https://contoso, https://fabrikam", "https://contoso, https://fabrikam")]
+        public void Given_HostNames_When_Instantiated_Then_It_Should_Return_Result(string hostnames, string expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__HostNames", hostnames);
+
+            var config = ConfigurationResolver.Resolve();
+            var settings = config.Get<OpenApiSettings>("OpenApi");
+
+            settings.HostNames.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, false)]
+        [DataRow("", false)]
+        [DataRow("true", true)]
+        [DataRow("false", false)]
+        public void Given_ForceHttps_When_Instantiated_Then_It_Should_Return_Result(string https, bool expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__ForceHttps", https);
+
+            var config = ConfigurationResolver.Resolve();
+            var settings = config.Get<OpenApiSettings>("OpenApi");
+
+            settings.ForceHttps.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, false)]
+        [DataRow("", false)]
+        [DataRow("true", true)]
+        [DataRow("false", false)]
+        public void Given_ForceHttp_When_Instantiated_Then_It_Should_Return_Result(string http, bool expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__ForceHttp", http);
+
+            var config = ConfigurationResolver.Resolve();
+            var settings = config.Get<OpenApiSettings>("OpenApi");
+
+            settings.ForceHttp.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, false)]
+        [DataRow("", false)]
+        [DataRow("true", true)]
+        [DataRow("false", false)]
+        public void Given_HideSwaggerUI_When_Instantiated_Then_It_Should_Return_Result(string hide, bool expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__HideSwaggerUI", hide);
+
+            var config = ConfigurationResolver.Resolve();
+            var settings = config.Get<OpenApiSettings>("OpenApi");
+
+            settings.HideSwaggerUI.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, false)]
+        [DataRow("", false)]
+        [DataRow("true", true)]
+        [DataRow("false", false)]
+        public void Given_HideDocument_When_Instantiated_Then_It_Should_Return_Result(string hide, bool expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__HideDocument", hide);
+
+            var config = ConfigurationResolver.Resolve();
+            var settings = config.Get<OpenApiSettings>("OpenApi");
+
+            settings.HideDocument.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, null)]
+        [DataRow("", null)]
+        [DataRow("lorem", "lorem")]
+        public void Given_ApiKey_When_Instantiated_Then_It_Should_Return_Result(string apiKey, string expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__ApiKey", apiKey);
+
+            var config = ConfigurationResolver.Resolve();
+            var settings = config.Get<OpenApiSettings>("OpenApi");
+
+            settings.ApiKey.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, null)]
+        [DataRow("", null)]
+        [DataRow("Anonymous", AuthorizationLevel.Anonymous)]
+        [DataRow("anonymous", AuthorizationLevel.Anonymous)]
+        [DataRow("Function", AuthorizationLevel.Function)]
+        [DataRow("function", AuthorizationLevel.Function)]
+        [DataRow("User", AuthorizationLevel.User)]
+        [DataRow("user", AuthorizationLevel.User)]
+        [DataRow("Admin", AuthorizationLevel.Admin)]
+        [DataRow("admin", AuthorizationLevel.Admin)]
+        [DataRow("System", AuthorizationLevel.System)]
+        [DataRow("system", AuthorizationLevel.System)]
+        public void Given_AuthLevelDoc_When_Instantiated_Then_It_Should_Return_Result(string authLevel, AuthorizationLevel? expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__AuthLevel__Document", authLevel);
+
+            var config = ConfigurationResolver.Resolve();
+            var settings = config.Get<OpenApiSettings>("OpenApi");
+
+            settings.AuthLevel.Document.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, null)]
+        [DataRow("", null)]
+        [DataRow("Anonymous", AuthorizationLevel.Anonymous)]
+        [DataRow("anonymous", AuthorizationLevel.Anonymous)]
+        [DataRow("Function", AuthorizationLevel.Function)]
+        [DataRow("function", AuthorizationLevel.Function)]
+        [DataRow("User", AuthorizationLevel.User)]
+        [DataRow("user", AuthorizationLevel.User)]
+        [DataRow("Admin", AuthorizationLevel.Admin)]
+        [DataRow("admin", AuthorizationLevel.Admin)]
+        [DataRow("System", AuthorizationLevel.System)]
+        [DataRow("system", AuthorizationLevel.System)]
+        public void Given_AuthLevelUI_When_Instantiated_Then_It_Should_Return_Result(string authLevel, AuthorizationLevel? expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__AuthLevel__UI", authLevel);
+
+            var config = ConfigurationResolver.Resolve();
+            var settings = config.Get<OpenApiSettings>("OpenApi");
+
+            settings.AuthLevel.UI.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, null)]
+        [DataRow("", null)]
+        [DataRow("lorem", "lorem")]
+        public void Given_BackendProxyUrl_When_Instantiated_Then_It_Should_Return_Result(string url, string expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__BackendProxyUrl", url);
+
+            var config = ConfigurationResolver.Resolve();
+            var settings = config.Get<OpenApiSettings>("OpenApi");
+
+            settings.BackendProxyUrl.Should().Be(expected);
+        }
+    }
+}

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/Fakes/FakeFunctionsWorkerApplicationBuilder.cs
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/Fakes/FakeFunctionsWorkerApplicationBuilder.cs
@@ -1,0 +1,23 @@
+using System;
+
+using Microsoft.Azure.Functions.Worker.Middleware;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Fakes
+{
+    public class FakeFunctionsWorkerApplicationBuilder : IFunctionsWorkerApplicationBuilder
+    {
+        public FakeFunctionsWorkerApplicationBuilder(IServiceCollection services)
+        {
+            this.Services = services.ThrowIfNullOrDefault();
+        }
+
+        public IServiceCollection Services { get; private set; }
+
+        public IFunctionsWorkerApplicationBuilder Use(Func<FunctionExecutionDelegate, FunctionExecutionDelegate> middleware)
+        {
+            return this;
+        }
+    }
+}

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/Fakes/FakeHttpRequestData.cs
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/Fakes/FakeHttpRequestData.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Claims;
+
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Primitives;
@@ -10,11 +11,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Fakes
 {
     public class FakeHttpRequestData : HttpRequestData
     {
-        public FakeHttpRequestData(FunctionContext functionContext, Uri uri, Dictionary<string, string> headers, Stream body = null) : base(functionContext)
+        public FakeHttpRequestData(FunctionContext functionContext, Uri uri, Dictionary<string, string> headers, List<ClaimsIdentity> identities = null, Stream body = null) : base(functionContext)
         {
             this.Url = uri;
-            this.Body = body;
             this.Headers = new HttpHeadersCollection(headers ?? new Dictionary<string, string>());
+            this.Identities = identities ?? new List<ClaimsIdentity>();
+            this.Body = body;
         }
 
         public override Stream Body { get; }
@@ -23,9 +25,9 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Fakes
 
         public override IReadOnlyCollection<IHttpCookie> Cookies => throw new NotImplementedException();
 
-        public override Uri Url { get;}
+        public override Uri Url { get; }
 
-        public override IEnumerable<ClaimsIdentity> Identities => throw new NotImplementedException();
+        public override IEnumerable<ClaimsIdentity> Identities { get; }
 
         public override string Method => throw new NotImplementedException();
 

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/OpenApiWorkerStartupTests.cs
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/OpenApiWorkerStartupTests.cs
@@ -1,0 +1,31 @@
+using System.Linq;
+
+using FluentAssertions;
+
+using Microsoft.Azure.Functions.Worker.Extensions.OpenApi;
+using Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Configurations;
+using Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Fakes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests
+{
+    [TestClass]
+    public class OpenApiWorkerStartupTests
+    {
+        [TestMethod]
+        public void Given_Type_When_Initialised_Then_It_Should_Return_Result()
+        {
+            var services = new ServiceCollection();
+            var builder = new FakeFunctionsWorkerApplicationBuilder(services);
+
+            var startup = new OpenApiWorkerStartup();
+            startup.Configure(builder);
+
+            services.SingleOrDefault(p => p.ServiceType == typeof(OpenApiSettings)).Should().NotBeNull();
+            services.SingleOrDefault(p => p.ServiceType == typeof(IOpenApiTriggerFunction)).Should().NotBeNull();
+            services.SingleOrDefault(p => p.ServiceType == typeof(IOpenApiHttpTriggerContext)).Should().NotBeNull();
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/Fakes/FakeWebJobsBuilder.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/Fakes/FakeWebJobsBuilder.cs
@@ -1,0 +1,15 @@
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests.Fakes
+{
+    public class FakeWebJobsBuilder : IWebJobsBuilder
+    {
+        public FakeWebJobsBuilder(IServiceCollection services)
+        {
+            this.Services = services.ThrowIfNullOrDefault();
+        }
+
+        public IServiceCollection Services { get; }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/HttpRequestObjectTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/HttpRequestObjectTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Claims;
 using System.Text;
 
 using FluentAssertions;
@@ -27,11 +28,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests
         }
 
         [DataTestMethod]
-        [DataRow("http", "localhost", 80, "hello", "world", "lorem ipsum")]
-        [DataRow("http", "localhost", 7071, "lorem", "ipsum", "hello world")]
-        [DataRow("https", "localhost", 443, "hello", "world", "lorem ipsum")]
-        [DataRow("https", "localhost", 47071, "lorem", "ipsum", "hello world")]
-        public void Given_Parameter_When_Instantiated_Then_It_Should_Return_Result(string scheme, string hostname, int port, string key, string value, string payload)
+        [DataRow("http", "localhost", 80, "hello", "world", "dolor", "lorem ipsum")]
+        [DataRow("http", "localhost", 7071, "lorem", "ipsum", "sit", "hello world")]
+        [DataRow("https", "localhost", 443, "hello", "world", "amet", "lorem ipsum")]
+        [DataRow("https", "localhost", 47071, "lorem", "ipsum", "consectetur", "hello world")]
+        public void Given_Parameter_When_Instantiated_Then_It_Should_Return_Result(string scheme, string hostname, int port, string key, string value, string authType, string payload)
         {
             var req = new Mock<HttpRequest>();
             req.SetupGet(p => p.Scheme).Returns(scheme);
@@ -48,6 +49,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests
             var query = new QueryCollection(dict);
             req.SetupGet(p => p.Query).Returns(query);
 
+            var identities = new List<ClaimsIdentity>()
+            {
+                new ClaimsIdentity(
+                    authenticationType: authType,
+                    nameType: ClaimsIdentity.DefaultNameClaimType,
+                    roleType: ClaimsIdentity.DefaultRoleClaimType)
+            };
+            var user = new ClaimsPrincipal(identities);
+
+            req.SetupGet(p => p.HttpContext.User).Returns(user);
+
             var bytes = Encoding.UTF8.GetBytes(payload);
             var body = new MemoryStream(bytes);
             req.SetupGet(p => p.Body).Returns(body);
@@ -58,7 +70,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests
             result.Host.Value.Should().Be(baseHost);
             result.Headers.Should().ContainKey(key);
             result.Query.Should().ContainKey(key);
-            ((string) result.Query[key]).Should().Be(value);
+            ((string)result.Query[key]).Should().Be(value);
+            result.Identities.Where(p => p.AuthenticationType == authType).Should().HaveCount(1);
             (new StreamReader(result.Body)).ReadToEnd().Should().Be(payload);
 
             body.Dispose();

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/OpenApiWebJobsStartupTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests/OpenApiWebJobsStartupTests.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+
+using FluentAssertions;
+
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests.Fakes;
+using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Tests
+{
+    [TestClass]
+    public class OpenApiWebJobsStartupTests
+    {
+        [TestMethod]
+        public void Given_Type_When_Initialised_Then_It_Should_Return_Result()
+        {
+            var services = new ServiceCollection();
+            var builder = new FakeWebJobsBuilder(services);
+
+            var startup = new OpenApiWebJobsStartup();
+            startup.Configure(builder);
+
+            services.SingleOrDefault(p => p.ServiceType == typeof(OpenApiSettings)).Should().NotBeNull();
+            services.SingleOrDefault(p => p.ServiceType == typeof(IFunctionProvider)).Should().NotBeNull();
+            services.SingleOrDefault(p => p.ServiceType == typeof(IOpenApiHttpTriggerContext)).Should().NotBeNull();
+            services.SingleOrDefault(p => p.ServiceType == typeof(IExtensionConfigProvider)).Should().NotBeNull();
+        }
+    }
+}


### PR DESCRIPTION
After this PR, the package will be:

* To read OpenAPI settings from environment variables through the `OpenApiSettings` instance on out-of-proc worker, and use it as an injected dependency
* To use JWT claims within the OpenAPI related pages - `swagger/ui`, ``swagger.json`, etc, for better authN scenarios
