### PR TITLE
Flexibility to choose `Microsoft.AspNetcore.App` on the isolate worker

### DIFF
--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Extensions/OpenApiHttpRequestDataExtensions.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Extensions/OpenApiHttpRequestDataExtensions.cs
@@ -2,7 +2,13 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.AspNetCore.Http;
+
+#if NETSTANDARD2_0
+
 using Microsoft.AspNetCore.Http.Internal;
+
+#endif
+
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.csproj
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\builds\worker.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
@@ -21,13 +21,29 @@
     <VersionSuffix></VersionSuffix> -->
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+  <PropertyGroup Condition="'$(Configuration)'=='Debug' And '$(TargetFramework)'=='netstandard2.0'">
     <DocumentationFile>bin\Debug\netstandard2.0\Microsoft.Azure.Functions.Worker.Extensions.OpenApi.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug' And '$(TargetFramework)'=='net6.0'">
+    <DocumentationFile>bin\Debug\net6.0\Microsoft.Azure.Functions.Worker.Extensions.OpenApi.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug' And '$(TargetFramework)'=='net7.0'">
+    <DocumentationFile>bin\Debug\net7.0\Microsoft.Azure.Functions.Worker.Extensions.OpenApi.xml</DocumentationFile>
+  </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+  <PropertyGroup Condition="'$(Configuration)'=='Release' And '$(TargetFramework)'=='netstandard2.0'">
     <DocumentationFile>bin\Release\netstandard2.0\Microsoft.Azure.Functions.Worker.Extensions.OpenApi.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release' And '$(TargetFramework)'=='net6.0'">
+    <DocumentationFile>bin\Release\net6.0\Microsoft.Azure.Functions.Worker.Extensions.OpenApi.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release' And '$(TargetFramework)'=='net7.0'">
+    <DocumentationFile>bin\Release\net7.0\Microsoft.Azure.Functions.Worker.Extensions.OpenApi.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)'!='netstandard2.0' ">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 
   <ItemGroup>
     <!--<FrameworkReference Include="Microsoft.AspNetCore.App" />-->

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.csproj
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
Resolves to #534 #536

After this PR, the `dotnet-isolated` worker function app will be able to render properly against the `QueryCollection` object.