### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows_oca/oca-slack-issue-commented.yaml
+++ b/.github/workflows_oca/oca-slack-issue-commented.yaml
@@ -23,7 +23,7 @@ jobs:
       run: |
         $isOcaParticipant = "${{ contains(secrets.OCA_PARTICIPANTS, github.event.comment.user.login) }}"
 
-        echo "::set-output name=isOcaParticipant::$isOcaParticipant"
+        echo "isOcaParticipant=$isOcaParticipant" >> $GITHUB_OUTPUT
 
     - name: Add a label
       if: ${{ steps.checkpoint.outputs.isOcaParticipant == 'true' }}

--- a/.github/workflows_oca/oca-slack-issue-opened.yaml
+++ b/.github/workflows_oca/oca-slack-issue-opened.yaml
@@ -23,7 +23,7 @@ jobs:
       run: |
         $isOcaParticipant = "${{ contains(secrets.OCA_PARTICIPANTS, github.event.issue.user.login) }}"
 
-        echo "::set-output name=isOcaParticipant::$isOcaParticipant"
+        echo "isOcaParticipant=$isOcaParticipant" >> $GITHUB_OUTPUT
 
     - name: Add a label
       if: ${{ steps.checkpoint.outputs.isOcaParticipant == 'true' }}

--- a/.github/workflows_oca/oca-slack-issue-reopened.yaml
+++ b/.github/workflows_oca/oca-slack-issue-reopened.yaml
@@ -23,7 +23,7 @@ jobs:
       run: |
         $isOcaParticipant = "${{ contains(secrets.OCA_PARTICIPANTS, github.event.issue.user.login) }}"
 
-        echo "::set-output name=isOcaParticipant::$isOcaParticipant"
+        echo "isOcaParticipant=$isOcaParticipant" >> $GITHUB_OUTPUT
 
     - name: Add a label
       if: ${{ steps.checkpoint.outputs.isOcaParticipant == 'true' }}

--- a/.github/workflows_oca/oca-slack-pr-created.yaml
+++ b/.github/workflows_oca/oca-slack-pr-created.yaml
@@ -26,7 +26,7 @@ jobs:
         echo "Requester: ${{ github.event.pull_request.user.login }}"
         $isOcaParticipant = "${{ contains(secrets.OCA_PARTICIPANTS, github.event.pull_request.user.login) }}"
 
-        echo "::set-output name=isOcaParticipant::$isOcaParticipant"
+        echo "isOcaParticipant=$isOcaParticipant" >> $GITHUB_OUTPUT
 
     - name: Add a label
       if: ${{ steps.checkpoint.outputs.isOcaParticipant == 'true' }}

--- a/.github/workflows_oca/oca-slack-pr-updated.yaml
+++ b/.github/workflows_oca/oca-slack-pr-updated.yaml
@@ -26,7 +26,7 @@ jobs:
         echo "Requester: ${{ github.event.pull_request.user.login }}"
         $isOcaParticipant = "${{ contains(secrets.OCA_PARTICIPANTS, github.event.pull_request.user.login) }}"
 
-        echo "::set-output name=isOcaParticipant::$isOcaParticipant"
+        echo "isOcaParticipant=$isOcaParticipant" >> $GITHUB_OUTPUT
 
     - name: Send a message to Slack
       if: ${{ steps.checkpoint.outputs.isOcaParticipant == 'true' }}


### PR DESCRIPTION
## Description

Resolve  #553  

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
echo "::set-output name=isOcaParticipant::$isOcaParticipant"
```

**TO-BE**

```yml
echo "isOcaParticipant=$isOcaParticipant" >> $GITHUB_OUTPUT
```