### PR TITLE
Fixed typo about enum Identifier summary and variable name

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Enums/BindingDataType.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Enums/BindingDataType.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums
         Binary = 2,
 
         /// <summary>
-        /// Identifies <c>Undefined</c>.
+        /// Identifies <c>Stream</c>.
         /// </summary>
         Stream = 3,
     }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/AssemblyExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/AssemblyExtensions.cs
@@ -35,11 +35,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
                              .Where(x => x.FullName.StartsWith("Microsoft.Azure.WebJobs.Extensions.OpenApi") == false &&
                                          x.FullName.StartsWith("Microsoft.Azure.Functions.Worker.Extensions.OpenApi") == false)
                              .ToList();
-            foreach (var asmbly in assemblies)
+            foreach (var referenceAssembly in assemblies)
             {
                 try
                 {
-                    types.AddRange(Assembly.Load(asmbly).GetTypes());
+                    types.AddRange(Assembly.Load(referenceAssembly).GetTypes());
                 }
                 catch (ReflectionTypeLoadException ex)
                 {
@@ -62,14 +62,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
 
             var assemblies = dlls.Select(p =>
                                   {
-                                      var asmbly = default(Assembly);
+                                      var referenceAssembly = default(Assembly);
                                       try
                                       {
-                                          asmbly = Assembly.LoadFrom(p);
+                                          referenceAssembly = Assembly.LoadFrom(p);
                                       }
                                       catch { }
 
-                                      return asmbly;
+                                      return referenceAssembly;
                                   })
                                  .Where(p => p != null);
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/AssemblyExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/AssemblyExtensions.cs
@@ -35,11 +35,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
                              .Where(x => x.FullName.StartsWith("Microsoft.Azure.WebJobs.Extensions.OpenApi") == false &&
                                          x.FullName.StartsWith("Microsoft.Azure.Functions.Worker.Extensions.OpenApi") == false)
                              .ToList();
-            foreach (var referenceAssembly in assemblies)
+            foreach (var asmbly in assemblies)
             {
                 try
                 {
-                    types.AddRange(Assembly.Load(referenceAssembly).GetTypes());
+                    types.AddRange(Assembly.Load(asmbly).GetTypes());
                 }
                 catch (ReflectionTypeLoadException ex)
                 {
@@ -62,14 +62,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
 
             var assemblies = dlls.Select(p =>
                                   {
-                                      var referenceAssembly = default(Assembly);
+                                      var asmbly = default(Assembly);
                                       try
                                       {
-                                          referenceAssembly = Assembly.LoadFrom(p);
+                                          asmbly = Assembly.LoadFrom(p);
                                       }
                                       catch { }
 
-                                      return referenceAssembly;
+                                      return asmbly;
                                   })
                                  .Where(p => p != null);
 


### PR DESCRIPTION
Problem
1. the Summary for the BindingDatatype Stream identifier in the BindingDatatype.cs file incorrectly stated Identifies <c>Undefined</c>.
2. the name of a loop variable in the AssemblyExtentions.cs file was misspelled asmbly.

Solve
1. Corrected the Summary for the Stream identifier to Identifies <c>Stream</c>.
2. Rename the variable to referenceAssembly instead of asmbly.

Expectations
- Fix typos to improve readability for the viewer.