### PR TITLE
create test for OpenApiWriterFactory.cs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,8 @@
     "MD025": {
       "front_matter_title": ""
     }
-  }
+  },
+  "githubPullRequests.ignoredPullRequestBranches": [
+    "main"
+  ]
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/OpenApiWriterFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/OpenApiWriterFactoryTests.cs
@@ -19,20 +19,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
 
         [DataTestMethod]
         [DataRow(OpenApiFormat.Json)]
-        [DataRow(OpenApiFormat.Yaml)]
-        public void CreateInstance_Should_Return_Correct_OpenApiWriter(OpenApiFormat format)
+        public void CreateInstance_Should_Return_OpenApiJsonWriter(OpenApiFormat format)
         {
             var result = OpenApiWriterFactory.CreateInstance(format, _writer);
 
             result.Should().NotBeNull();
-            if (format == OpenApiFormat.Json)
-            {
-                result.Should().BeOfType<OpenApiJsonWriter>();
-            }
-            else if (format == OpenApiFormat.Yaml)
-            {
-                result.Should().BeOfType<OpenApiYamlWriter>();
-            }
+            result.Should().BeOfType<OpenApiJsonWriter>();
+        }
+
+        [DataTestMethod]
+        [DataRow(OpenApiFormat.Yaml)]
+        public void CreateInstance_Should_Return_OpenApiYamlWriter(OpenApiFormat format)
+        {
+            var result = OpenApiWriterFactory.CreateInstance(format, _writer);
+
+            result.Should().NotBeNull();
+            result.Should().BeOfType<OpenApiYamlWriter>();
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/OpenApiWriterFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/OpenApiWriterFactoryTests.cs
@@ -1,42 +1,38 @@
+using FluentAssertions;
 using Microsoft.OpenApi;
 using Microsoft.OpenApi.Writers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
-using System;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
 {
     [TestClass]
     public class OpenApiWriterFactoryTests
     {
-        [TestMethod]
-        public void CreateInstance_Should_Return_Json_Writer()
+        private StringWriter _writer;
+
+        [TestInitialize]
+        public void Init()
         {
-            // Arrange
-            OpenApiFormat format = OpenApiFormat.Json;
-            StringWriter writer = new StringWriter();
-
-            // Act
-            IOpenApiWriter result = OpenApiWriterFactory.CreateInstance(format, writer);
-
-            // Assert
-            Assert.IsNotNull(result);
-            Assert.IsInstanceOfType(result, typeof(OpenApiJsonWriter));
+            _writer = new StringWriter();
         }
 
-        [TestMethod]
-        public void CreateInstance_Should_Return_Yaml_Writer()
+        [DataTestMethod]
+        [DataRow(OpenApiFormat.Json)]
+        [DataRow(OpenApiFormat.Yaml)]
+        public void CreateInstance_Should_Return_Correct_OpenApiWriter(OpenApiFormat format)
         {
-            // Arrange
-            OpenApiFormat format = OpenApiFormat.Yaml;
-            StringWriter writer = new StringWriter();
+            var result = OpenApiWriterFactory.CreateInstance(format, _writer);
 
-            // Act
-            IOpenApiWriter result = OpenApiWriterFactory.CreateInstance(format, writer);
-
-            // Assert
-            Assert.IsNotNull(result);
-            Assert.IsInstanceOfType(result, typeof(OpenApiYamlWriter));
+            result.Should().NotBeNull();
+            if (format == OpenApiFormat.Json)
+            {
+                result.Should().BeOfType<OpenApiJsonWriter>();
+            }
+            else if (format == OpenApiFormat.Yaml)
+            {
+                result.Should().BeOfType<OpenApiYamlWriter>();
+            }
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/OpenApiWriterFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/OpenApiWriterFactoryTests.cs
@@ -3,6 +3,7 @@ using Microsoft.OpenApi;
 using Microsoft.OpenApi.Writers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
+using System;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
 {
@@ -18,23 +19,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
         }
 
         [DataTestMethod]
-        [DataRow(OpenApiFormat.Json)]
-        public void CreateInstance_Should_Return_OpenApiJsonWriter(OpenApiFormat format)
+        [DataRow(OpenApiFormat.Json, typeof(OpenApiJsonWriter))]
+        [DataRow(OpenApiFormat.Yaml, typeof(OpenApiYamlWriter))]
+        public void Given_OpenApiFormat_When_CreateInstance_Then_Should_Return_Correct_OpenApiWriter(OpenApiFormat format, Type writerType)
         {
             var result = OpenApiWriterFactory.CreateInstance(format, _writer);
 
             result.Should().NotBeNull();
-            result.Should().BeOfType<OpenApiJsonWriter>();
-        }
-
-        [DataTestMethod]
-        [DataRow(OpenApiFormat.Yaml)]
-        public void CreateInstance_Should_Return_OpenApiYamlWriter(OpenApiFormat format)
-        {
-            var result = OpenApiWriterFactory.CreateInstance(format, _writer);
-
-            result.Should().NotBeNull();
-            result.Should().BeOfType<OpenApiYamlWriter>();
+            result.Should().BeOfType(writerType);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/OpenApiWriterFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/OpenApiWriterFactoryTests.cs
@@ -1,0 +1,42 @@
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Writers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
+{
+    [TestClass]
+    public class OpenApiWriterFactoryTests
+    {
+        [TestMethod]
+        public void CreateInstance_Should_Return_Json_Writer()
+        {
+            // Arrange
+            OpenApiFormat format = OpenApiFormat.Json;
+            StringWriter writer = new StringWriter();
+
+            // Act
+            IOpenApiWriter result = OpenApiWriterFactory.CreateInstance(format, writer);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(OpenApiJsonWriter));
+        }
+
+        [TestMethod]
+        public void CreateInstance_Should_Return_Yaml_Writer()
+        {
+            // Arrange
+            OpenApiFormat format = OpenApiFormat.Yaml;
+            StringWriter writer = new StringWriter();
+
+            // Act
+            IOpenApiWriter result = OpenApiWriterFactory.CreateInstance(format, writer);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(OpenApiYamlWriter));
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/OpenApiWriterFactoryTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/OpenApiWriterFactoryTests.cs
@@ -21,12 +21,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
         [DataTestMethod]
         [DataRow(OpenApiFormat.Json, typeof(OpenApiJsonWriter))]
         [DataRow(OpenApiFormat.Yaml, typeof(OpenApiYamlWriter))]
-        public void Given_OpenApiFormat_When_CreateInstance_Then_Should_Return_Correct_OpenApiWriter(OpenApiFormat format, Type writerType)
+        public void Given_OpenApiFormat_When_CreateInstance_Then_Should_Return_Correct_OpenApiWriter(OpenApiFormat format, Type expected)
         {
             var result = OpenApiWriterFactory.CreateInstance(format, _writer);
 
             result.Should().NotBeNull();
-            result.Should().BeOfType(writerType);
+            result.Should().BeOfType(expected);
         }
     }
 }


### PR DESCRIPTION
Describe the issue
The code above contains a test class for OpenApiWriterFactory in the Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests namespace. This class has two test methods, CreateInstance_Should_Return_Json_Writer() and CreateInstance_Should_Return_Yaml_Writer(), that check if the OpenApiWriterFactory creates the correct writer instance for the specified OpenApiFormat.

To Reproduce
To reproduce the issue, follow these steps:

Open the solution containing the Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests project.
Build the solution to ensure all dependencies are resolved.
Run the test class OpenApiWriterFactoryTests.
Observe the results of the test methods.
Expected behavior
The test methods should pass, indicating that the OpenApiWriterFactory correctly creates the writer instance for the specified OpenApiFormat.
Screenshots
N/A

Environment

OS: [Windows]
Browser [chrome]
Version [.net 7.0]
Additional context
No additional context.