### PR TITLE
Feat: Add ByteTypeVisitor, CharTypeVisitor

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ByteTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ByteTypeVisitor.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.OpenApi.Models;
+using Newtonsoft.Json.Serialization;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
+{
+    /// <summary>
+    /// This represents the type visitor for <see cref="byte"/>.
+    /// </summary>
+    public class ByteTypeVisitor : TypeVisitor
+    {
+        /// <inheritdoc />
+        public ByteTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
+        public override bool IsVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type, TypeCode.Byte);
+
+            return isVisitable;
+        }
+
+        /// <inheritdoc />
+        public override void Visit(IAcceptor acceptor, KeyValuePair<string, Type> type, NamingStrategy namingStrategy, params Attribute[] attributes)
+        {
+            this.Visit(acceptor, name: type.Key, title: null, dataType: "string", dataFormat: "byte", attributes: attributes);
+        }
+
+        /// <inheritdoc />
+        public override bool IsParameterVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type);
+
+            return isVisitable;
+        }
+
+        /// <inheritdoc />
+        public override OpenApiSchema ParameterVisit(Type type, NamingStrategy namingStrategy)
+        {
+            return this.ParameterVisit(dataType: "string", dataFormat: "byte");
+        }
+
+        /// <inheritdoc />
+        public override bool IsPayloadVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type);
+
+            return isVisitable;
+        }
+
+        /// <inheritdoc />
+        public override OpenApiSchema PayloadVisit(Type type, NamingStrategy namingStrategy)
+        {
+            return this.PayloadVisit(dataType: "string", dataFormat: "byte");
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/CharTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/CharTypeVisitor.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.OpenApi.Models;
+using Newtonsoft.Json.Serialization;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
+{
+    /// <summary>
+    /// This represents the type visitor for <see cref="char"/>.
+    /// </summary>
+    public class CharTypeVisitor : TypeVisitor
+    {
+        /// <inheritdoc />
+        public CharTypeVisitor(VisitorCollection visitorCollection)
+            : base(visitorCollection)
+        {
+        }
+
+        /// <inheritdoc />
+        public override bool IsVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type, TypeCode.Char);
+
+            return isVisitable;
+        }
+
+        /// <inheritdoc />
+        public override void Visit(IAcceptor acceptor, KeyValuePair<string, Type> type, NamingStrategy namingStrategy, params Attribute[] attributes)
+        {
+            this.Visit(acceptor, name: type.Key, title: null, dataType: "string", dataFormat: null, attributes: attributes);
+
+            var instance = acceptor as OpenApiSchemaAcceptor;
+
+            if (instance.Schemas.TryGetValue(type.Key, out var schema))
+            {
+                schema.MinLength = 1;
+                schema.MaxLength = 1;
+            }
+        }
+
+        /// <inheritdoc />
+        public override bool IsParameterVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type);
+
+            return isVisitable;
+        }
+
+        /// <inheritdoc />
+        public override OpenApiSchema ParameterVisit(Type type, NamingStrategy namingStrategy)
+        {
+            return this.ParameterVisit(dataType: "string", dataFormat: null);
+        }
+
+        /// <inheritdoc />
+        public override bool IsPayloadVisitable(Type type)
+        {
+            var isVisitable = this.IsVisitable(type);
+
+            return isVisitable;
+        }
+
+        /// <inheritdoc />
+        public override OpenApiSchema PayloadVisit(Type type, NamingStrategy namingStrategy)
+        {
+            return this.PayloadVisit(dataType: "string", dataFormat: null);
+        }
+    }
+}


### PR DESCRIPTION
In Issue #396 , I noticed that error is occurred by there is no type for byte, char.
So, I add ByteTypeVisitor and CharTypeVisitor with reference to OpenAPI Specification, JSON Schema ruleset.

1. byte : datatype: string, dataformat : byte
2. char : datatype: string, minlength : 1, maxlength : 1