### PR TITLE
Replacing Moq to NSubstitute in Functions.Worker.Extensions.OpenApi.Tests 

### DIFF
--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/DocumentTests.cs
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/DocumentTests.cs
@@ -14,10 +14,9 @@ using Microsoft.OpenApi;
 using Microsoft.OpenApi.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using Moq;
-
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
+using NSubstitute;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
 {
@@ -35,8 +34,9 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [TestMethod]
         public void Given_That_When_InitialiseDocument_Invoked_Then_It_Should_Return_Result()
         {
-            var helper = new Mock<IDocumentHelper>();
-            var doc = new Document(helper.Object);
+            
+            var helper =  Substitute.For<IDocumentHelper>();
+            var doc = new Document(helper);
 
             var result = doc.InitialiseDocument();
 
@@ -48,8 +48,9 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [DataRow("hello world")]
         public void Given_Info_When_AddMetadata_Invoked_Then_It_Should_Return_Result(string title)
         {
-            var helper = new Mock<IDocumentHelper>();
-            var doc = new Document(helper.Object);
+            
+            var helper = Substitute.For<IDocumentHelper>();
+            var doc = new Document(helper);
 
             var info = new OpenApiInfo() { Title = title };
 
@@ -75,18 +76,19 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [DataRow("https", "localhost", 47071, "api")]
         public void Given_NoOptions_When_AddServer_Invoked_Then_It_Should_Return_Result(string scheme, string host, int port, string routePrefix)
         {
-            var helper = new Mock<IDocumentHelper>();
-            var doc = new Document(helper.Object);
+            var helper = Substitute.For<IDocumentHelper>();
+            var doc = new Document(helper);
 
             var ports = new[] { 80, 443 };
             var baseHost = $"{host}{(ports.Contains(port) ? string.Empty : $":{port}")}";
             var url = $"{scheme}://{baseHost}/{routePrefix}".TrimEnd('/');
-            var req = new Mock<IHttpRequestDataObject>();
-            req.SetupGet(p => p.Scheme).Returns(scheme);
-            req.SetupGet(p => p.Host).Returns(new HostString(baseHost));
+            var req = Substitute.For<IHttpRequestDataObject>();
+            req.Scheme.Returns(scheme);
+            req.Host.Returns(new HostString(baseHost));
+
 
             var result = doc.InitialiseDocument()
-                            .AddServer(req.Object, routePrefix);
+                            .AddServer(req, routePrefix);
 
             result.OpenApiDocument.Servers.Should().HaveCount(1);
             result.OpenApiDocument.Servers.First().Url.Should().Be(url);
@@ -107,21 +109,23 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [DataRow("https", "localhost", 47071, "api")]
         public void Given_EmptyOptions_When_AddServer_Invoked_Then_It_Should_Return_Result(string scheme, string host, int port, string routePrefix)
         {
-            var helper = new Mock<IDocumentHelper>();
-            var doc = new Document(helper.Object);
+            
+            var helper = Substitute.For<IDocumentHelper>();
+            var doc = new Document(helper);
 
             var ports = new[] { 80, 443 };
             var baseHost = $"{host}{(ports.Contains(port) ? string.Empty : $":{port}")}";
             var url = $"{scheme}://{baseHost}/{routePrefix}".TrimEnd('/');
-            var req = new Mock<IHttpRequestDataObject>();
-            req.SetupGet(p => p.Scheme).Returns(scheme);
-            req.SetupGet(p => p.Host).Returns(new HostString(baseHost));
+            var req = Substitute.For<IHttpRequestDataObject>();
+            req.Scheme.Returns(scheme);
+            req.Host.Returns(new HostString(baseHost));
 
-            var options = new Mock<IOpenApiConfigurationOptions>();
-            options.SetupGet(p => p.Servers).Returns(new List<OpenApiServer>());
+            var options = Substitute.For<IOpenApiConfigurationOptions>();
+            options.Servers.Returns(new List<OpenApiServer>());
+            
 
             var result = doc.InitialiseDocument()
-                            .AddServer(req.Object, routePrefix, options.Object);
+                            .AddServer(req, routePrefix, options);
 
             result.OpenApiDocument.Servers.Should().HaveCount(1);
             result.OpenApiDocument.Servers.First().Url.Should().Be(url);
@@ -142,23 +146,26 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [DataRow("https", "localhost", 47071, "api", "helloworld")]
         public void Given_ExtraServers_And_Include_When_AddServer_Invoked_Then_It_Should_Return_Result(string scheme, string host, int port, string routePrefix, string server)
         {
-            var helper = new Mock<IDocumentHelper>();
-            var doc = new Document(helper.Object);
+            
+            var helper = Substitute.For<IDocumentHelper>();
+            var doc = new Document(helper);
 
             var ports = new[] { 80, 443 };
             var baseHost = $"{host}{(ports.Contains(port) ? string.Empty : $":{port}")}";
             var url = $"{scheme}://{baseHost}/{routePrefix}".TrimEnd('/');
-            var req = new Mock<IHttpRequestDataObject>();
-            req.SetupGet(p => p.Scheme).Returns(scheme);
-            req.SetupGet(p => p.Host).Returns(new HostString(baseHost));
+            var req = Substitute.For<IHttpRequestDataObject>();
+            req.Scheme.Returns(scheme);
+            req.Host.Returns(new HostString(baseHost));
+            
 
             var servers = new List<OpenApiServer>() { new OpenApiServer() { Url = server } };
-            var options = new Mock<IOpenApiConfigurationOptions>();
-            options.SetupGet(p => p.Servers).Returns(servers);
-            options.SetupGet(p => p.IncludeRequestingHostName).Returns(true);
+            var options = Substitute.For<IOpenApiConfigurationOptions>();
+            options.Servers.Returns(servers);
+            options.IncludeRequestingHostName.Returns(true);
+            
 
             var result = doc.InitialiseDocument()
-                            .AddServer(req.Object, routePrefix, options.Object);
+                            .AddServer(req, routePrefix, options);
 
             result.OpenApiDocument.Servers.Should().HaveCount(2);
             result.OpenApiDocument.Servers.First().Url.Should().Be(url);
@@ -180,23 +187,26 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [DataRow("https", "localhost", 47071, "api", "helloworld")]
         public void Given_ExtraServers_And_Exclude_When_AddServer_Invoked_Then_It_Should_Return_Result(string scheme, string host, int port, string routePrefix, string server)
         {
-            var helper = new Mock<IDocumentHelper>();
-            var doc = new Document(helper.Object);
+            
+            var helper = Substitute.For<IDocumentHelper>();
+            var doc = new Document(helper);
 
             var ports = new[] { 80, 443 };
             var baseHost = $"{host}{(ports.Contains(port) ? string.Empty : $":{port}")}";
             var url = $"{scheme}://{baseHost}/{routePrefix}".TrimEnd('/');
-            var req = new Mock<IHttpRequestDataObject>();
-            req.SetupGet(p => p.Scheme).Returns(scheme);
-            req.SetupGet(p => p.Host).Returns(new HostString(baseHost));
+            var req = Substitute.For<IHttpRequestDataObject>();
+            
+            
+            req.Scheme.Returns(scheme);
+            req.Host.Returns(new HostString(baseHost));
 
             var servers = new List<OpenApiServer>() { new OpenApiServer() { Url = server } };
-            var options = new Mock<IOpenApiConfigurationOptions>();
-            options.SetupGet(p => p.Servers).Returns(servers);
-            options.SetupGet(p => p.IncludeRequestingHostName).Returns(false);
+            var options = Substitute.For<IOpenApiConfigurationOptions>();
+            options.Servers.Returns(servers);
+            options.IncludeRequestingHostName.Returns(false);
 
             var result = doc.InitialiseDocument()
-                            .AddServer(req.Object, routePrefix, options.Object);
+                            .AddServer(req, routePrefix, options);
 
             result.OpenApiDocument.Servers.Should().HaveCount(1);
             result.OpenApiDocument.Servers.First().Url.Should().Be(server);
@@ -217,17 +227,18 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [DataRow("https", "localhost:47071", null, "https://localhost:47071")]
         public void Given_NullOptions_When_AddServer_Invoked_Then_It_Should_Return_BaseUrl(string scheme, string host, string routePrefix, string expected)
         {
-            var helper = new Mock<IDocumentHelper>();
-            var doc = new Document(helper.Object);
+            var helper = Substitute.For<IDocumentHelper>();
+            var doc = new Document(helper);
 
-            var req = new Mock<IHttpRequestDataObject>();
-            req.SetupGet(p => p.Scheme).Returns(scheme);
+            var req = Substitute.For<IHttpRequestDataObject>();
+            req.Scheme.Returns(scheme);
+            
 
             var hostString = new HostString(host);
-            req.SetupGet(p => p.Host).Returns(hostString);
+            req.Host.Returns(hostString);
 
             var result = doc.InitialiseDocument()
-                            .AddServer(req.Object, routePrefix, null);
+                            .AddServer(req, routePrefix, null);
 
             result.OpenApiDocument.Servers.Should().HaveCount(1);
             result.OpenApiDocument.Servers.First().Url.Should().Be(expected);
@@ -284,22 +295,23 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [DataRow("https", "localhost:47071", null, false, false, "https://localhost:47071")]
         public void Given_Options_When_AddServer_Invoked_Then_It_Should_Return_BaseUrl(string scheme, string host, string routePrefix, bool forceHttps, bool forceHttp, string expected)
         {
-            var helper = new Mock<IDocumentHelper>();
-            var doc = new Document(helper.Object);
+            var helper = Substitute.For<IDocumentHelper>();
+            var doc = new Document(helper);
 
-            var req = new Mock<IHttpRequestDataObject>();
-            req.SetupGet(p => p.Scheme).Returns(scheme);
+            var req = Substitute.For<IHttpRequestDataObject>();
+            req.Scheme.Returns(scheme);
 
             var hostString = new HostString(host);
-            req.SetupGet(p => p.Host).Returns(hostString);
+            req.Host.Returns(hostString);
 
-            var options = new Mock<IOpenApiConfigurationOptions>();
-            options.SetupGet(p => p.ForceHttps).Returns(forceHttps);
-            options.SetupGet(p => p.ForceHttp).Returns(forceHttp);
-            options.SetupGet(p => p.Servers).Returns(new List<OpenApiServer>());
+            var options = Substitute.For<IOpenApiConfigurationOptions>();
+            options.ForceHttps.Returns(forceHttps);
+            options.ForceHttp.Returns(forceHttp);
+            options.Servers.Returns(new List<OpenApiServer>());
+            
 
             var result = doc.InitialiseDocument()
-                            .AddServer(req.Object, routePrefix, options.Object);
+                            .AddServer(req, routePrefix, options);
 
             result.OpenApiDocument.Servers.Should().HaveCount(1);
             result.OpenApiDocument.Servers.First().Url.Should().Be(expected);
@@ -308,8 +320,8 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [TestMethod]
         public void Given_Null_When_AddNamingStrategy_Invoked_Then_It_Should_Throw_Exception()
         {
-            var helper = new Mock<IDocumentHelper>();
-            var doc = new Document(helper.Object);
+            var helper = Substitute.For<IDocumentHelper>();
+            var doc = new Document(helper);
 
             Action action = () => doc.AddNamingStrategy(null);
 
@@ -321,8 +333,8 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         {
             var field = typeof(Document).GetField("_strategy", BindingFlags.Instance | BindingFlags.NonPublic);
             var strategy = new DefaultNamingStrategy();
-            var helper = new Mock<IDocumentHelper>();
-            var doc = new Document(helper.Object);
+            var helper = Substitute.For<IDocumentHelper>();
+            var doc = new Document(helper);
 
             var result = doc.AddNamingStrategy(strategy);
 
@@ -333,8 +345,8 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [TestMethod]
         public void Given_Null_When_AddVisitors_Invoked_Then_It_Should_Throw_Exception()
         {
-            var helper = new Mock<IDocumentHelper>();
-            var doc = new Document(helper.Object);
+            var helper = Substitute.For<IDocumentHelper>();
+            var doc = new Document(helper);
 
             Action action = () => doc.AddVisitors(null);
 
@@ -346,8 +358,8 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         {
             var field = typeof(Document).GetField("_collection", BindingFlags.Instance | BindingFlags.NonPublic);
             var collection = new VisitorCollection();
-            var helper = new Mock<IDocumentHelper>();
-            var doc = new Document(helper.Object);
+            var helper = Substitute.For<IDocumentHelper>();
+            var doc = new Document(helper);
 
             var result = doc.AddVisitors(collection);
 
@@ -358,8 +370,8 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [TestMethod]
         public void Given_Null_When_ApplyDocumentFilters_Invoked_Then_It_Should_Throw_Exception()
         {
-            var helper = new Mock<IDocumentHelper>();
-            var doc = new Document(helper.Object);
+            var helper = Substitute.For<IDocumentHelper>();
+            var doc = new Document(helper);
 
             Action action = () => doc.ApplyDocumentFilters(null);
 
@@ -369,24 +381,24 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [TestMethod]
         public void Given_That_When_ApplyDocumentFilters_Invoked_Then_It_Should_Invoke_Each_Filter()
         {
-            var documentFilter = new Mock<IDocumentFilter>();
-            var collection = new DocumentFilterCollection(new List<IDocumentFilter> { documentFilter.Object });
+            var documentFilter = Substitute.For<IDocumentFilter>();
+            var collection = new DocumentFilterCollection(new List<IDocumentFilter> { documentFilter });
             var openApiDocument = new OpenApiDocument();
             var doc = new Document(openApiDocument);
 
-            var req = new Mock<IHttpRequestDataObject>();
+            var req = Substitute.For<IHttpRequestDataObject>();
 
-            doc.AddServer(req.Object, "");
+            doc.AddServer(req, "");
             doc.ApplyDocumentFilters(collection);
 
-            documentFilter.Verify(x => x.Apply(req.Object, openApiDocument), Times.Once());
+            documentFilter.Received(1).Apply(req, openApiDocument);
         }
 
         [TestMethod]
         public async Task Given_VersionAndFormat_When_RenderAsync_Invoked_Then_It_Should_Return_Result()
         {
-            var helper = new Mock<IDocumentHelper>();
-            var doc = new Document(helper.Object);
+            var helper = Substitute.For<IDocumentHelper>();
+            var doc = new Document(helper);
 
             var result = await doc.InitialiseDocument()
                                   .RenderAsync(OpenApiSpecVersion.OpenApi2_0, OpenApiFormat.Json);
@@ -399,12 +411,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [TestMethod]
         public async Task Given_Metadata_When_RenderAsync_Invoked_Then_It_Should_Return_Result()
         {
-            var helper = new Mock<IDocumentHelper>();
+            var helper = Substitute.For<IDocumentHelper>();
 
             var title = "hello world";
             var info = new OpenApiInfo() { Title = title };
 
-            var doc = new Document(helper.Object);
+            var doc = new Document(helper);
 
             var result = await doc.InitialiseDocument()
                                   .AddMetadata(info)
@@ -418,21 +430,22 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [TestMethod]
         public async Task Given_ServerDetails_When_RenderAsync_Invoked_Then_It_Should_Return_Result()
         {
-            var helper = new Mock<IDocumentHelper>();
+            var helper = Substitute.For<IDocumentHelper>();
 
             var scheme = "https";
             var host = "localhost";
             var routePrefix = "api";
 
             var url = $"{scheme}://{host}";
-            var req = new Mock<IHttpRequestDataObject>();
-            req.SetupGet(p => p.Scheme).Returns(scheme);
-            req.SetupGet(p => p.Host).Returns(new HostString(host));
-
-            var doc = new Document(helper.Object);
+            var req = Substitute.For<IHttpRequestDataObject>();
+            
+            req.Scheme.Returns(scheme);
+            
+            req.Host.Returns(new HostString(host)); 
+            var doc = new Document(helper);
 
             var result = await doc.InitialiseDocument()
-                                  .AddServer(req.Object, routePrefix)
+                                  .AddServer(req, routePrefix)
                                   .RenderAsync(OpenApiSpecVersion.OpenApi2_0, OpenApiFormat.Json);
 
             dynamic json = JObject.Parse(result);
@@ -447,23 +460,24 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [DataRow(false, "fabrikam.com", "contoso.com")]
         public async Task Given_ServerDetails_With_ConfigurationOptions_When_RenderAsync_Invoked_Then_It_Should_Return_Result(bool includeRequestingHostName, string host, string expected)
         {
-            var helper = new Mock<IDocumentHelper>();
+            var helper = Substitute.For<IDocumentHelper>();
 
             var scheme = "https";
             var routePrefix = "api";
 
-            var req = new Mock<IHttpRequestDataObject>();
-            req.SetupGet(p => p.Scheme).Returns(scheme);
-            req.SetupGet(p => p.Host).Returns(new HostString(host));
+            var req = Substitute.For<IHttpRequestDataObject>();
+            req.Scheme.Returns(scheme);
+            req.Host.Returns(new HostString(host));
 
-            var options = new Mock<IOpenApiConfigurationOptions>();
-            options.SetupGet(p => p.IncludeRequestingHostName).Returns(includeRequestingHostName);
-            options.SetupGet(p => p.Servers).Returns(new List<OpenApiServer>() { new OpenApiServer() { Url = $"{scheme}://contoso.com/{routePrefix}" } });
+            var options = Substitute.For<IOpenApiConfigurationOptions>();
+            options.IncludeRequestingHostName.Returns(includeRequestingHostName);
+            options.Servers.Returns(new List<OpenApiServer>(){new OpenApiServer() {Url = $"{scheme}://contoso.com/{routePrefix}"}});
+            
 
-            var doc = new Document(helper.Object);
+            var doc = new Document(helper);
 
             var result = await doc.InitialiseDocument()
-                                  .AddServer(req.Object, routePrefix, options.Object)
+                                  .AddServer(req, routePrefix, options)
                                   .RenderAsync(OpenApiSpecVersion.OpenApi2_0, OpenApiFormat.Json);
 
             dynamic json = JObject.Parse(result);
@@ -476,21 +490,21 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [TestMethod]
         public async Task Given_ServerDetails_WithNullRoutePrefix_When_RenderAsync_Invoked_Then_It_Should_Return_Result_OpenApiV2()
         {
-            var helper = new Mock<IDocumentHelper>();
+            var helper = Substitute.For<IDocumentHelper>();
 
             var scheme = "https";
             var host = "localhost";
             string routePrefix = null;
 
             var url = $"{scheme}://{host}";
-            var req = new Mock<IHttpRequestDataObject>();
-            req.SetupGet(p => p.Scheme).Returns(scheme);
-            req.SetupGet(p => p.Host).Returns(new HostString(host));
+            var req = Substitute.For<IHttpRequestDataObject>();
+            req.Scheme.Returns(scheme);
+            req.Host.Returns(new HostString(host));
 
-            var doc = new Document(helper.Object);
+            var doc = new Document(helper);
 
             var result = await doc.InitialiseDocument()
-                                  .AddServer(req.Object, routePrefix)
+                                  .AddServer(req, routePrefix)
                                   .RenderAsync(OpenApiSpecVersion.OpenApi2_0, OpenApiFormat.Json);
 
             dynamic json = JObject.Parse(result);
@@ -503,21 +517,22 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [TestMethod]
         public async Task Given_ServerDetails_WithNullRoutePrefix_When_RenderAsync_Invoked_Then_It_Should_Return_Result_OpenApiV3()
         {
-            var helper = new Mock<IDocumentHelper>();
+            var helper = Substitute.For<IDocumentHelper>();
 
             var scheme = "https";
             var host = "localhost";
             string routePrefix = null;
 
             var url = $"{scheme}://{host}";
-            var req = new Mock<IHttpRequestDataObject>();
-            req.SetupGet(p => p.Scheme).Returns(scheme);
-            req.SetupGet(p => p.Host).Returns(new HostString(host));
+            var req = Substitute.For<IHttpRequestDataObject>();
+            req.Scheme.Returns(scheme);
+            req.Host.Returns(new HostString(host));
+            
 
-            var doc = new Document(helper.Object);
+            var doc = new Document(helper);
 
             var result = await doc.InitialiseDocument()
-                                  .AddServer(req.Object, routePrefix)
+                                  .AddServer(req, routePrefix)
                                   .RenderAsync(OpenApiSpecVersion.OpenApi3_0, OpenApiFormat.Json);
 
             dynamic json = JObject.Parse(result);
@@ -535,21 +550,22 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [TestMethod]
         public async Task Given_ServerDetails_WithEmptyRoutePrefix_When_RenderAsync_Invoked_Then_It_Should_Return_Result()
         {
-            var helper = new Mock<IDocumentHelper>();
+            var helper = Substitute.For<IDocumentHelper>();
 
             var scheme = "https";
             var host = "localhost";
             var routePrefix = string.Empty;
 
             var url = $"{scheme}://{host}";
-            var req = new Mock<IHttpRequestDataObject>();
-            req.SetupGet(p => p.Scheme).Returns(scheme);
-            req.SetupGet(p => p.Host).Returns(new HostString(host));
+            var req = Substitute.For<IHttpRequestDataObject>();
+            req.Scheme.Returns(scheme);
+            req.Host.Returns(new HostString(host));
+            
 
-            var doc = new Document(helper.Object);
+            var doc = new Document(helper);
 
             var result = await doc.InitialiseDocument()
-                                  .AddServer(req.Object, routePrefix)
+                                  .AddServer(req, routePrefix)
                                   .RenderAsync(OpenApiSpecVersion.OpenApi2_0, OpenApiFormat.Json);
 
             dynamic json = JObject.Parse(result);
@@ -565,20 +581,20 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [DataRow("https", "localhost", null)]
         public async Task Given_ServerDetails_When_RenderAsync_Invoked_Then_It_Should_Return_Result(string scheme, string host, string routePrefix)
         {
-            var helper = new Mock<IDocumentHelper>();
+            var helper = Substitute.For<IDocumentHelper>();
 
             var url = $"{scheme}://{host}/{routePrefix}";
             var uri = new Uri(url);
-            var req = new Mock<IHttpRequestDataObject>();
-            req.SetupGet(p => p.Scheme).Returns(scheme);
+            var req = Substitute.For<IHttpRequestDataObject>();
+            req.Scheme.Returns(scheme);
+            req.Host.Returns(new HostString(host));
+            
 
-            req.SetupGet(p => p.Host).Returns(new HostString(host));
 
-
-            var doc = new Document(helper.Object);
+            var doc = new Document(helper);
 
             var result = await doc.InitialiseDocument()
-                                  .AddServer(req.Object, routePrefix)
+                                  .AddServer(req, routePrefix)
                                   .RenderAsync(OpenApiSpecVersion.OpenApi3_0, OpenApiFormat.Json);
 
             dynamic json = JObject.Parse(result);
@@ -590,4 +606,3 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         }
     }
 }
-

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/Extensions/HttpRequestDataExtensionsTests.cs
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/Extensions/HttpRequestDataExtensionsTests.cs
@@ -8,7 +8,7 @@ using Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Fakes;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using Moq;
+using NSubstitute;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
 {
@@ -26,12 +26,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
         [TestMethod]
         public void Given_NullHeader_When_Headers_Invoked_Then_It_Should_Return_Result()
         {
-            var context = new Mock<FunctionContext>();
+            var context = Substitute.For<FunctionContext>();
 
             var baseHost = "localhost";
             var uri = Uri.TryCreate($"http://{baseHost}", UriKind.Absolute, out var tried) ? tried : null;
 
-            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri, headers: null);
+            var req = (HttpRequestData) new FakeHttpRequestData(context, uri, headers: null);
 
             var result = OpenApiHttpRequestDataExtensions.Headers(req);
 
@@ -41,14 +41,14 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
         [TestMethod]
         public void Given_NoHeader_When_Headers_Invoked_Then_It_Should_Return_Result()
         {
-            var context = new Mock<FunctionContext>();
+            var context = Substitute.For<FunctionContext>();
 
             var baseHost = "localhost";
             var uri = Uri.TryCreate($"http://{baseHost}", UriKind.Absolute, out var tried) ? tried : null;
 
             var headers = new Dictionary<string, string>();
 
-            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri, headers: headers);
+            var req = (HttpRequestData) new FakeHttpRequestData(context, uri, headers: headers);
 
             var result = OpenApiHttpRequestDataExtensions.Headers(req);
 
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
         [DataRow("hello=world&lorem=ipsum", "hello", "lorem")]
         public void Given_Headers_When_Headers_Invoked_Then_It_Should_Return_Result(string headerstring, params string[] keys)
         {
-            var context = new Mock<FunctionContext>();
+            var context = Substitute.For<FunctionContext>();
 
             var baseHost = "localhost";
             var uri = Uri.TryCreate($"http://{baseHost}", UriKind.Absolute, out var tried) ? tried : null;
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
             var kvps = headerstring.Split('&').ToDictionary(p => p.Split('=').First(), p => p.Split('=').Last());
             var headers = new Dictionary<string, string>(kvps);
 
-            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri, headers: headers);
+            var req = (HttpRequestData) new FakeHttpRequestData(context, uri, headers: headers);
 
             var result = OpenApiHttpRequestDataExtensions.Headers(req);
 
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
         [DataRow("hello=world&lorem=ipsum", "lorem", "ipsum")]
         public void Given_Headers_When_Header_Invoked_Then_It_Should_Return_Result(string headerstring, string key, string expected)
         {
-            var context = new Mock<FunctionContext>();
+            var context = Substitute.For<FunctionContext>();
 
             var baseHost = "localhost";
             var uri = Uri.TryCreate($"http://{baseHost}", UriKind.Absolute, out var tried) ? tried : null;
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
             var kvps = headerstring.Split('&').ToDictionary(p => p.Split('=').First(), p => p.Split('=').Last());
             var headers = new Dictionary<string, string>(kvps);
 
-            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri, headers: headers);
+            var req = (HttpRequestData) new FakeHttpRequestData(context, uri, headers: headers);
 
             var result = (string) OpenApiHttpRequestDataExtensions.Header(req, key);
 
@@ -108,12 +108,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
         [TestMethod]
         public void Given_NullHeader_When_Header_Invoked_Then_It_Should_Return_Result()
         {
-            var context = new Mock<FunctionContext>();
+            var context = Substitute.For<FunctionContext>();
 
             var baseHost = "localhost";
             var uri = Uri.TryCreate($"http://{baseHost}", UriKind.Absolute, out var tried) ? tried : null;
 
-            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri, headers: null);
+            var req = (HttpRequestData) new FakeHttpRequestData(context, uri, headers: null);
 
             var result = (string) OpenApiHttpRequestDataExtensions.Header(req, "hello");
 
@@ -123,14 +123,14 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
         [TestMethod]
         public void Given_NoHeader_When_Header_Invoked_Then_It_Should_Return_Result()
         {
-            var context = new Mock<FunctionContext>();
+            var context = Substitute.For<FunctionContext>();
 
             var baseHost = "localhost";
             var uri = Uri.TryCreate($"http://{baseHost}", UriKind.Absolute, out var tried) ? tried : null;
 
             var headers = new Dictionary<string, string>();
 
-            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri, headers: headers);
+            var req = (HttpRequestData) new FakeHttpRequestData(context, uri, headers: headers);
 
             var result = (string) OpenApiHttpRequestDataExtensions.Query(req, "hello");
 
@@ -148,12 +148,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
         [TestMethod]
         public void Given_NullQuerystring_When_Queries_Invoked_Then_It_Should_Return_Result()
         {
-            var context = new Mock<FunctionContext>();
+            var context = Substitute.For<FunctionContext>();
 
             var baseHost = "localhost";
             var uri = Uri.TryCreate($"http://{baseHost}", UriKind.Absolute, out var tried) ? tried : null;
 
-            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri, headers: null);
+            var req = (HttpRequestData) new FakeHttpRequestData(context, uri, headers: null);
 
             var result = OpenApiHttpRequestDataExtensions.Queries(req);
 
@@ -165,12 +165,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
         [DataRow("")]
         public void Given_NoQuerystring_When_Queries_Invoked_Then_It_Should_Return_Result(string querystring)
         {
-            var context = new Mock<FunctionContext>();
+            var context = Substitute.For<FunctionContext>();
 
             var baseHost = "localhost";
             var uri = Uri.TryCreate($"http://{baseHost}?{querystring}", UriKind.Absolute, out var tried) ? tried : null;
 
-            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri, headers: null);
+            var req = (HttpRequestData) new FakeHttpRequestData(context, uri, headers: null);
 
             var result = OpenApiHttpRequestDataExtensions.Queries(req);
 
@@ -182,12 +182,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
         [DataRow("hello=world&lorem=ipsum", "hello", "lorem")]
         public void Given_Querystring_When_Queries_Invoked_Then_It_Should_Return_Result(string querystring, params string[] keys)
         {
-            var context = new Mock<FunctionContext>();
+            var context = Substitute.For<FunctionContext>();
 
             var baseHost = "localhost";
             var uri = Uri.TryCreate($"http://{baseHost}?{querystring}", UriKind.Absolute, out var tried) ? tried : null;
 
-            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri, headers: null);
+            var req = (HttpRequestData) new FakeHttpRequestData(context, uri, headers: null);
 
             var result = OpenApiHttpRequestDataExtensions.Queries(req);
 
@@ -209,12 +209,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
         [DataRow("hello=world&lorem=ipsum", "lorem", "ipsum")]
         public void Given_Querystring_When_Query_Invoked_Then_It_Should_Return_Result(string querystring, string key, string expected)
         {
-            var context = new Mock<FunctionContext>();
+            var context = Substitute.For<FunctionContext>();
 
             var baseHost = "localhost";
             var uri = Uri.TryCreate($"http://{baseHost}?{querystring}", UriKind.Absolute, out var tried) ? tried : null;
 
-            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri, headers: null);
+            var req = (HttpRequestData) new FakeHttpRequestData(context, uri, headers: null);
 
             var result = (string) OpenApiHttpRequestDataExtensions.Query(req, key);
 
@@ -224,12 +224,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
         [TestMethod]
         public void Given_NullQuerystring_When_Query_Invoked_Then_It_Should_Return_Result()
         {
-            var context = new Mock<FunctionContext>();
+            var context = Substitute.For<FunctionContext>();
 
             var baseHost = "localhost";
             var uri = Uri.TryCreate($"http://{baseHost}", UriKind.Absolute, out var tried) ? tried : null;
 
-            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri, headers: null);
+            var req = (HttpRequestData) new FakeHttpRequestData(context, uri, headers: null);
 
             var result = (string) OpenApiHttpRequestDataExtensions.Query(req, "hello");
 
@@ -241,12 +241,12 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Extensions
         [DataRow("")]
         public void Given_NoQuerystring_When_Query_Invoked_Then_It_Should_Return_Result(string querystring)
         {
-            var context = new Mock<FunctionContext>();
+            var context = Substitute.For<FunctionContext>();
 
             var baseHost = "localhost";
             var uri = Uri.TryCreate($"http://{baseHost}?{querystring}", UriKind.Absolute, out var tried) ? tried : null;
 
-            var req = (HttpRequestData) new FakeHttpRequestData(context.Object, uri, headers: null);
+            var req = (HttpRequestData) new FakeHttpRequestData(context, uri, headers: null);
 
             var result = (string) OpenApiHttpRequestDataExtensions.Query(req, "hello");
 

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/HttpRequestObjectTests.cs
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/HttpRequestObjectTests.cs
@@ -11,7 +11,7 @@ using Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.Fakes;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using Moq;
+using NSubstitute;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
 {
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         [DataRow("https", "localhost", 47071, "lorem", "ipsum", "consectetur", "hello world")]
         public void Given_Parameter_When_Instantiated_Then_It_Should_Return_Result(string scheme, string hostname, int port, string key, string value, string authType, string payload)
         {
-            var context = new Mock<FunctionContext>();
+            var context = Substitute.For<FunctionContext>();
 
             var ports = new[] { 80, 443 };
             var baseHost = $"{hostname}{(ports.Contains(port) ? string.Empty : $":{port}")}";
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
             var bytes = Encoding.UTF8.GetBytes(payload);
             var body = new MemoryStream(bytes);
 
-            var req = (HttpRequestData)new FakeHttpRequestData(context.Object, uri, headers, identities, body);
+            var req = (HttpRequestData)new FakeHttpRequestData(context, uri, headers, identities, body);
 
             var result = new HttpRequestObject(req);
 

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.csproj
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.csproj
@@ -20,7 +20,6 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Moq" Version="4.18.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.0" />
     <PackageReference Include="NSubstitute" Version="5.0.0" />

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.csproj
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Moq" Version="4.18.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.0" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/OpenApiHttpTriggerContextTests.cs
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/OpenApiHttpTriggerContextTests.cs
@@ -15,7 +15,7 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.OpenApi;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using Moq;
+using NSubstitute;
 
 using Newtonsoft.Json.Serialization;
 
@@ -221,11 +221,11 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         public async Task Given_Authorization_When_AuthorizeAsync_Invoked_Then_It_Should_Return_Result()
         {
             var location = new FileInfo(Assembly.GetExecutingAssembly().Location).Directory.FullName;
-            var req = new Mock<IHttpRequestDataObject>();
+            var req = Substitute.For<IHttpRequestDataObject>();
             var context = new OpenApiHttpTriggerContext();
 
             var result = await context.SetApplicationAssemblyAsync(location, false)
-                                      .AuthorizeAsync(req.Object);
+                                      .AuthorizeAsync(req);
 
             result.StatusCode.Should().Be(FakeOpenApiHttpTriggerAuthorization.StatusCode);
             result.ContentType.Should().Be(FakeOpenApiHttpTriggerAuthorization.ContentType);


### PR DESCRIPTION
In #598 Issue, we need to replace Moq with Something.. 
So, I replace Moq Library to Nsubstitute in Functions.Worker.Extensions.OpenApi.Tests Project.