### PR TITLE
Replace Moq Library to Nsubstitute in WebJobs Core.Tests project

### DIFF
--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/DefaultOpenApiHttpTriggerAuthorizationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/DefaultOpenApiHttpTriggerAuthorizationTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using Moq;
+using NSubstitute;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
 {
@@ -16,10 +16,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
         [TestMethod]
         public async Task Given_Type_When_Instantiated_Then_Properties_Should_Return_Null()
         {
-            var req = new Mock<IHttpRequestDataObject>();
+            var req = Substitute.For<IHttpRequestDataObject>();
             var auth = new DefaultOpenApiHttpTriggerAuthorization();
 
-            var result = await auth.AuthorizeAsync(req.Object).ConfigureAwait(false);
+            var result = await auth.AuthorizeAsync(req).ConfigureAwait(false);
 
             result.Should().BeNull();
         }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/OpenApiHttpTriggerAuthorizationTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/OpenApiHttpTriggerAuthorizationTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using Moq;
+using NSubstitute;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
 {
@@ -17,10 +17,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
         [TestMethod]
         public async Task Given_NoDeligate_When_AuthorizeAsync_Invoked_Then_It_Should_Return_Null()
         {
-            var req = new Mock<IHttpRequestDataObject>();
+            var req = Substitute.For<IHttpRequestDataObject>();
             var auth = new OpenApiHttpTriggerAuthorization();
 
-            var result = await auth.AuthorizeAsync(req.Object).ConfigureAwait(false);
+            var result = await auth.AuthorizeAsync(req).ConfigureAwait(false);
 
             result.Should().BeNull();
         }
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
         [DataRow(HttpStatusCode.Unauthorized, "text/plain", "Unauthorized")]
         public async Task Given_Deligate_Through_Constructor_When_AuthorizeAsync_Invoked_Then_It_Should_Return_Result(HttpStatusCode statusCode, string contentType, string payload)
         {
-            var req = new Mock<IHttpRequestDataObject>();
+            var req = Substitute.For<IHttpRequestDataObject>();
             var auth = new OpenApiHttpTriggerAuthorization(req =>
             {
                 var result = new OpenApiAuthorizationResult()
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
                 return Task.FromResult(result);
             });
 
-            var result = await auth.AuthorizeAsync(req.Object).ConfigureAwait(false);
+            var result = await auth.AuthorizeAsync(req).ConfigureAwait(false);
 
             result.Should().NotBeNull();
             result.StatusCode.Should().Be(statusCode);
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
         [DataRow(HttpStatusCode.Unauthorized, "text/plain", "Unauthorized")]
         public async Task Given_Deligate_Through_Property_When_AuthorizeAsync_Invoked_Then_It_Should_Return_Result(HttpStatusCode statusCode, string contentType, string payload)
         {
-            var req = new Mock<IHttpRequestDataObject>();
+            var req = Substitute.For<IHttpRequestDataObject>();
             var auth = new OpenApiHttpTriggerAuthorization
             {
                 Authorization = req =>
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
                 }
             };
 
-            var result = await auth.AuthorizeAsync(req.Object).ConfigureAwait(false);
+            var result = await auth.AuthorizeAsync(req).ConfigureAwait(false);
 
             result.Should().NotBeNull();
             result.StatusCode.Should().Be(statusCode);

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/HttpRequestDataObjectExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/HttpRequestDataObjectExtensionsTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using Moq;
+using NSubstitute;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
 {
@@ -26,10 +26,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
         [DataRow("https", "https")]
         public void Given_NullOptions_When_GetScheme_Invoked_Then_It_Should_Return_Result(string scheme, string expected)
         {
-            var req = new Mock<IHttpRequestDataObject>();
-            req.SetupGet(p => p.Scheme).Returns(scheme);
+            var req = Substitute.For<IHttpRequestDataObject>();
+            req.Scheme.Returns(scheme);
 
-            var result = HttpRequestDataObjectExtensions.GetScheme(req.Object, null);
+            var result = HttpRequestDataObjectExtensions.GetScheme(req, null);
 
             result.Should().Be(expected);
         }
@@ -45,14 +45,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
         [DataRow("https", false, false, "https")]
         public void Given_Options_When_GetScheme_Invoked_Then_It_Should_Return_Result(string scheme, bool forceHttps, bool forceHttp, string expected)
         {
-            var req = new Mock<IHttpRequestDataObject>();
-            req.SetupGet(p => p.Scheme).Returns(scheme);
+            var req = Substitute.For<IHttpRequestDataObject>();
+            req.Scheme.Returns(scheme);
 
-            var options = new Mock<IOpenApiConfigurationOptions>();
-            options.SetupGet(p => p.ForceHttps).Returns(forceHttps);
-            options.SetupGet(p => p.ForceHttp).Returns(forceHttp);
+            var options = Substitute.For<IOpenApiConfigurationOptions>();
+            options.ForceHttps.Returns(forceHttps);
+            options.ForceHttp.Returns(forceHttp);
 
-            var result = HttpRequestDataObjectExtensions.GetScheme(req.Object, options.Object);
+            var result = HttpRequestDataObjectExtensions.GetScheme(req, options);
 
             result.Should().Be(expected);
         }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/OpenApiHttpTriggerContextExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/OpenApiHttpTriggerContextExtensionsTests.cs
@@ -5,10 +5,11 @@ using FluentAssertions;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using Moq;
+using NSubstitute;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
 {
@@ -18,24 +19,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
         [TestMethod]
         public void Given_Null_Parameter_When_AuthorizeAsync_Invoked_Then_It_Should_Throw_Exception()
         {
-            var context = new Mock<IOpenApiHttpTriggerContext>();
+            var context = Substitute.For<IOpenApiHttpTriggerContext>();
 
             Func<Task> func = async () => await OpenApiHttpTriggerContextExtensions.AuthorizeAsync(null, null).ConfigureAwait(false);
             func.Should().ThrowAsync<ArgumentNullException>();
 
-            func = async () => await OpenApiHttpTriggerContextExtensions.AuthorizeAsync(Task.FromResult(context.Object), null).ConfigureAwait(false);
+            func = async () => await OpenApiHttpTriggerContextExtensions.AuthorizeAsync(Task.FromResult(context), null).ConfigureAwait(false);
             func.Should().ThrowAsync<ArgumentNullException>();
         }
 
         [TestMethod]
         public async Task Given_Parameter_When_AuthorizeAsync_Invoked_Then_It_Should_Return_Result()
         {
-            var context = new Mock<IOpenApiHttpTriggerContext>();
-            context.Setup(p => p.AuthorizeAsync(It.IsAny<IHttpRequestDataObject>())).ReturnsAsync(default(OpenApiAuthorizationResult));
+            var context = Substitute.For<IOpenApiHttpTriggerContext>();
+            context.AuthorizeAsync(Arg.Any<IHttpRequestDataObject>()).Returns(Task.FromResult(default(OpenApiAuthorizationResult)));
 
-            var req = new Mock<IHttpRequestDataObject>();
+            var req = Substitute.For<IHttpRequestDataObject>();
 
-            var result = await OpenApiHttpTriggerContextExtensions.AuthorizeAsync(Task.FromResult(context.Object), req.Object).ConfigureAwait(false);
+            var result = await OpenApiHttpTriggerContextExtensions.AuthorizeAsync(Task.FromResult(context), req).ConfigureAwait(false);
 
             result.Should().BeNull();
         }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/SwaggerUIExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/SwaggerUIExtensionsTests.cs
@@ -8,7 +8,7 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using Moq;
+using NSubstitute;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
 {
@@ -21,8 +21,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
             Func<Task> func = async () => await SwaggerUIExtensions.RenderAsync(null, null).ConfigureAwait(false);
             func.Should().ThrowAsync<ArgumentNullException>();
 
-            var ui = new Mock<ISwaggerUI>();
-            var task = Task.FromResult(ui.Object);
+            var ui = Substitute.For<ISwaggerUI>();
+            var task = Task.FromResult(ui);
 
             func = async () => await SwaggerUIExtensions.RenderAsync(task, null).ConfigureAwait(false);
             func.Should().ThrowAsync<ArgumentNullException>();
@@ -34,10 +34,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
             var endpoint = "swagger/ui";
             var rendered = "hello world";
 
-            var ui = new Mock<ISwaggerUI>();
-            ui.Setup(p => p.RenderAsync(It.IsAny<string>(), It.IsAny<OpenApiAuthLevelType>(), It.IsAny<string>())).ReturnsAsync(rendered);
+            var ui = Substitute.For<ISwaggerUI>();
+            ui.RenderAsync(Arg.Any<string>(), Arg.Any<OpenApiAuthLevelType>(), Arg.Any<string>()).Returns(Task.FromResult(rendered));
 
-            var task = Task.FromResult(ui.Object);
+            var task = Task.FromResult(ui);
 
             var result = await SwaggerUIExtensions.RenderAsync(task, endpoint).ConfigureAwait(false);
 
@@ -50,8 +50,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
             Func<Task> func = async () => await SwaggerUIExtensions.RenderOAuth2RedirectAsync(null, null).ConfigureAwait(false);
             func.Should().ThrowAsync<ArgumentNullException>();
 
-            var ui = new Mock<ISwaggerUI>();
-            var task = Task.FromResult(ui.Object);
+            var ui = Substitute.For<ISwaggerUI>();
+            var task = Task.FromResult(ui);
 
             func = async () => await SwaggerUIExtensions.RenderOAuth2RedirectAsync(task, null).ConfigureAwait(false);
             func.Should().ThrowAsync<ArgumentNullException>();
@@ -63,10 +63,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
             var endpoint = "oauth2-redirect.html";
             var rendered = "hello world";
 
-            var ui = new Mock<ISwaggerUI>();
-            ui.Setup(p => p.RenderOAuth2RedirectAsync(It.IsAny<string>(), It.IsAny<OpenApiAuthLevelType>(), It.IsAny<string>())).ReturnsAsync(rendered);
+            var ui = Substitute.For<ISwaggerUI>();
+            ui.RenderOAuth2RedirectAsync(Arg.Any<string>(), Arg.Any<OpenApiAuthLevelType>(), Arg.Any<string>()).Returns(Task.FromResult(rendered));
 
-            var task = Task.FromResult(ui.Object);
+            var task = Task.FromResult(ui);
 
             var result = await SwaggerUIExtensions.RenderOAuth2RedirectAsync(task, endpoint).ConfigureAwait(false);
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Filters/DocumentFilterCollectionTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Filters/DocumentFilterCollectionTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Filters;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using Moq;
+using NSubstitute;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Filters
 {
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Filters
         [DataRow(2)]
         public void Given_Filters_When_Instantated_Then_It_Should_Return_Result(int count)
         {
-            var filters = Enumerable.Range(0, count).Select(i => new Mock<IDocumentFilter>().Object).ToList();
+            var filters = Enumerable.Range(0, count).Select(i => Substitute.For<IDocumentFilter>()).ToList();
             var collection = new DocumentFilterCollection(filters);
 
             collection.DocumentFilters.Should().NotBeNull();

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Moq" Version="4.18.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.0" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/SwaggerUITests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/SwaggerUITests.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Primitives;
 using Microsoft.OpenApi.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using Moq;
+using NSubstitute;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
 {
@@ -35,15 +35,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
         [DataRow("https", "localhost:47071", null, "https://localhost:47071")]
         public void Given_NullOptions_When_AddServer_Invoked_Then_It_Should_Return_BaseUrl(string scheme, string host, string routePrefix, string expected)
         {
-            var req = new Mock<IHttpRequestDataObject>();
-            req.SetupGet(p => p.Scheme).Returns(scheme);
 
-            var hostString = new HostString(host);
-            req.SetupGet(p => p.Host).Returns(hostString);
+            var req = Substitute.For<IHttpRequestDataObject>();
+            req.Scheme.Returns(scheme); 
+            req.Host.Returns(new HostString(host)); 
 
             var ui = new SwaggerUI();
 
-            ui.AddServer(req.Object, routePrefix, null);
+            ui.AddServer(req, routePrefix, null);
 
             var fi = ui.GetType().GetField("_baseUrl", BindingFlags.Instance | BindingFlags.NonPublic);
 
@@ -101,20 +100,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
         [DataRow("https", "localhost:47071", null, false, false, "https://localhost:47071")]
         public void Given_Options_When_AddServer_Invoked_Then_It_Should_Return_BaseUrl(string scheme, string host, string routePrefix, bool forceHttps, bool forceHttp, string expected)
         {
-            var req = new Mock<IHttpRequestDataObject>();
-            req.SetupGet(p => p.Scheme).Returns(scheme);
+            var req = Substitute.For<IHttpRequestDataObject>();
+            req.Scheme.Returns(scheme);
+            req.Host.Returns(new HostString(host));
 
-            var hostString = new HostString(host);
-            req.SetupGet(p => p.Host).Returns(hostString);
-
-            var options = new Mock<IOpenApiConfigurationOptions>();
-            options.SetupGet(p => p.ForceHttps).Returns(forceHttps);
-            options.SetupGet(p => p.ForceHttp).Returns(forceHttp);
-            options.SetupGet(p => p.Servers).Returns(new List<OpenApiServer>());
+            var options = Substitute.For<IOpenApiConfigurationOptions>();
+            options.ForceHttps.Returns(forceHttps);
+            options.ForceHttp.Returns(forceHttp);
+            options.Servers.Returns(new List<OpenApiServer>()); 
 
             var ui = new SwaggerUI();
 
-            ui.AddServer(req.Object, routePrefix, options.Object);
+            ui.AddServer(req, routePrefix, options);
 
             var fi = ui.GetType().GetField("_baseUrl", BindingFlags.Instance | BindingFlags.NonPublic);
 
@@ -136,16 +133,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
         [DataRow("https", "localhost", null, true, "")]
         public void Given_NullOptions_When_AddServer_Invoked_Then_It_Should_Return_SwaggerUIApiPrefix(string scheme, string host, string routePrefix, bool optionsSet, string expected)
         {
-            var req = new Mock<IHttpRequestDataObject>();
-            req.SetupGet(p => p.Scheme).Returns(scheme);
-
-            var hostString = new HostString(host);
-            req.SetupGet(p => p.Host).Returns(hostString);
+            var req = Substitute.For<IHttpRequestDataObject>();
+            req.Scheme.Returns(scheme);
+            req.Host.Returns(new HostString(host));
 
             var ui = new SwaggerUI();
-            var options = new Mock<IOpenApiConfigurationOptions>();
-            options.SetupGet(p => p.Servers).Returns(new List<OpenApiServer>());
-            ui.AddServer(req.Object, routePrefix, optionsSet ? options.Object: null);
+            var options = Substitute.For<IOpenApiConfigurationOptions>();
+            options.Servers.Returns(new List<OpenApiServer>());
+
+            ui.AddServer(req, routePrefix, optionsSet ? options: null);
 
             var fi = ui.GetType().GetField("_swaggerUiApiPrefix", BindingFlags.Instance | BindingFlags.NonPublic);
 
@@ -252,9 +248,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests
             {
                 queryDict["code"] = queryKey;
             }
-            var req = new Mock<IHttpRequestDataObject>();
-            req.SetupGet(p => p.Query).Returns(new QueryCollection(queryDict));
-            uiType.GetField("_req", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(ui, req.Object);
+            var req = Substitute.For<IHttpRequestDataObject>();
+            req.Query.Returns(new QueryCollection(queryDict));
+            uiType.GetField("_req", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(ui, req);
 
             //Set BaseUrl
             uiType.GetField("_baseUrl", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(ui, baseUrl);


### PR DESCRIPTION
To Solve Issue #598,
Replaced Moq Library to Nsubstitute in 7 files in test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests project

The test is complete
![image](https://github.com/Azure/azure-functions-openapi-extension/assets/83288181/bf6e4b77-1eb3-474e-829f-a04f7ecfaf51)

