### PR TITLE
Fix GetUnderlyingType() can't get Type when Tpye is NestedCollection

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
@@ -557,7 +557,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
 
             if (type.IsArrayType())
             {
-                return type.GetGenericArguments()[0];
+                return type.GetGenericArguments() != null && type.GetGenericArguments().Length > 0 ? type.GetGenericArguments()[0] : type.BaseType.GetGenericArguments()[0] ;
             }
 
             return null;

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/TypeExtensions.cs
@@ -461,7 +461,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
 
             if (type.IsOpenApiArray())
             {
-                underlyingType = type.GetElementType() ?? type.GetGenericArguments()[0];
+                underlyingType = type.GetElementType() ?? (type.GetGenericArguments() != null && type.GetGenericArguments().Length > 0 ? type.GetGenericArguments()[0] : type.BaseType.GetGenericArguments()[0]) ;
             }
 
             if (type.IsOpenApiDictionary())

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_ApplicationJson_ArrayObject_Tests.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_ApplicationJson_ArrayObject_Tests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
         [DataTestMethod]
         [DataRow("arrayObjectModel", "object", "stringObjectValue", "array", "stringObjectModel")]
         [DataRow("arrayObjectModel", "object", "objectArrayValue", "array", "list_object")]
-        [DataRow("arrayObjectModel", "object", "nestedCollectionValue", "array", "collection_int32")]
+        [DataRow("arrayObjectModel", "object", "nestedCollectionValue", "array", "collection_userDefine")]
         public void Given_OpenApiDocument_Then_It_Should_Return_ComponentSchemaPropertyItemReference(string @ref, string refType, string propertyName, string propertyType, string itemRef)
         {
             var items = this._doc["components"]["schemas"][@ref]["properties"][propertyName]["items"];

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_ApplicationJson_ArrayObject_Tests.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests/Get_ApplicationJson_ArrayObject_Tests.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
         [DataRow("arrayObjectModel", "object", "decimalValue", "array")]
         [DataRow("arrayObjectModel", "object", "stringObjectValue", "array")]
         [DataRow("arrayObjectModel", "object", "objectArrayValue", "array")]
+        [DataRow("arrayObjectModel", "object", "nestedCollectionValue", "array")]
         public void Given_OpenApiDocument_Then_It_Should_Return_ComponentSchemaProperty(string @ref, string refType, string propertyName, string propertyType)
         {
             var properties = this._doc["components"]["schemas"][@ref]["properties"];
@@ -107,6 +108,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests
         [DataTestMethod]
         [DataRow("arrayObjectModel", "object", "stringObjectValue", "array", "stringObjectModel")]
         [DataRow("arrayObjectModel", "object", "objectArrayValue", "array", "list_object")]
+        [DataRow("arrayObjectModel", "object", "nestedCollectionValue", "array", "collection_int32")]
         public void Given_OpenApiDocument_Then_It_Should_Return_ComponentSchemaPropertyItemReference(string @ref, string refType, string propertyName, string propertyType, string itemRef)
         {
             var items = this._doc["components"]["schemas"][@ref]["properties"][propertyName]["items"];

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Get_ApplicationJson_ArrayObject_HttpTrigger.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Get_ApplicationJson_ArrayObject_HttpTrigger.cs
@@ -24,5 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp
 
             return await Task.FromResult(result).ConfigureAwait(false);
         }
+
     }
+
 }

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Models/ArrayObjectModel.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Models/ArrayObjectModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Models
 {
@@ -14,5 +15,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Models
         public ISet<StringObjectModel> StringObjectValue { get; set; }
 
         public List<object[]> ObjectArrayValue { get; set; }
+
+        public Collection<Collection<int>> NestedCollectionValue { get; set; } 
     }
 }

--- a/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Models/ArrayObjectModel.cs
+++ b/test-integration/Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp/Models/ArrayObjectModel.cs
@@ -16,6 +16,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.TestApp.Models
 
         public List<object[]> ObjectArrayValue { get; set; }
 
-        public Collection<Collection<int>> NestedCollectionValue { get; set; } 
+        public Collection_Udf NestedCollectionValue { get; set; } 
     }
+
+    public class UserDefine { }
+
+    public class Collection_Udf : Collection<Collection<UserDefine>> { }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes/FakeAliasInheritanceModel.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes/FakeAliasInheritanceModel.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes
+{
+    public class FakeAliasInheritanceModel : Collection<Collection<FakeModel>>
+    {
+
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/TypeExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/TypeExtensionsTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-
+using System.Collections.ObjectModel;
 using FluentAssertions;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
@@ -119,6 +119,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
         [DataRow(typeof(List<int>), typeof(int))]
         [DataRow(typeof(List<bool>), typeof(bool))]
         [DataRow(typeof(List<FakeModel>), typeof(FakeModel))]
+        [DataRow(typeof(Collection<Collection<FakeModel>>), typeof(Collection<FakeModel>))]
         public void Given_ListType_When_GetUnderlyingType_Invoked_Then_It_Should_Return_Result(Type type, Type expected)
         {
             var result = TypeExtensions.GetUnderlyingType(type);

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/TypeExtensionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Extensions/TypeExtensionsTests.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Extensions
         [DataRow(typeof(List<int>), typeof(int))]
         [DataRow(typeof(List<bool>), typeof(bool))]
         [DataRow(typeof(List<FakeModel>), typeof(FakeModel))]
-        [DataRow(typeof(Collection<Collection<FakeModel>>), typeof(Collection<FakeModel>))]
+        [DataRow(typeof(FakeAliasInheritanceModel), typeof(Collection<FakeModel>))]
         public void Given_ListType_When_GetUnderlyingType_Invoked_Then_It_Should_Return_Result(Type type, Type expected)
         {
             var result = TypeExtensions.GetUnderlyingType(type);


### PR DESCRIPTION
in [Issue #588](https://github.com/Azure/azure-functions-openapi-extension/issues/588) when type is Nested Collection, GetUnderlying Method return null.   
The picture below reproduces the problem by temporarily implementing class and executing sample code.
### Problem
![code change](https://github.com/Azure/azure-functions-openapi-extension/assets/61729954/7b936cbb-8759-49f4-bf07-8788c537af2b)
![example](https://github.com/Azure/azure-functions-openapi-extension/assets/61729954/d1f2d2d5-bd88-4422-a2cc-aa25c7b3168f)
![error result](https://github.com/Azure/azure-functions-openapi-extension/assets/61729954/7984a919-ed51-4e4b-9aa5-cab13c73cbc9)
   
Below is the result of solving the problem by modifying the GetUnderlyingType() and GetSubType() methods.
### Result
![result1](https://github.com/Azure/azure-functions-openapi-extension/assets/61729954/c01e0dba-bb67-49a4-984c-b700718bc0fc)
![result2](https://github.com/Azure/azure-functions-openapi-extension/assets/61729954/de6a530c-e7a4-42f1-a7e9-f400f1059c23)
![result3](https://github.com/Azure/azure-functions-openapi-extension/assets/61729954/bd78ca0d-1d1c-4fed-a75a-29ca4e408a94)