### PR TITLE
Add : Set NamingStrategy Type

### DIFF
--- a/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.OutOfProc/Program.cs
+++ b/samples/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.OutOfProc/Program.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.OutOfP
                                     },
                                     Servers = DefaultOpenApiConfigurationOptions.GetHostNames(),
                                     OpenApiVersion = DefaultOpenApiConfigurationOptions.GetOpenApiVersion(),
+                                    OpenApiNamingStrategy = DefaultOpenApiConfigurationOptions.GetOpenApiNamingStrategy(),
                                     ExcludeRequestingHost = DefaultOpenApiConfigurationOptions.IsRequestingHostExcluded(),
                                     ForceHttps = DefaultOpenApiConfigurationOptions.IsHttpsForced(),
                                     ForceHttp = DefaultOpenApiConfigurationOptions.IsHttpForced(),

--- a/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.InProc/Startup.cs
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.InProc/Startup.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.FunctionApp.InProc
                                     },
                                     Servers = DefaultOpenApiConfigurationOptions.GetHostNames(),
                                     OpenApiVersion = DefaultOpenApiConfigurationOptions.GetOpenApiVersion(),
+                                    OpenApiNamingStrategy = DefaultOpenApiConfigurationOptions.GetOpenApiNamingStrategy(),
                                     ExcludeRequestingHost = DefaultOpenApiConfigurationOptions.IsRequestingHostExcluded(),
                                     ForceHttps = DefaultOpenApiConfigurationOptions.IsHttpsForced(),
                                     ForceHttp = DefaultOpenApiConfigurationOptions.IsHttpForced(),

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/OpenApiHttpTriggerContext.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/OpenApiHttpTriggerContext.cs
@@ -130,24 +130,11 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi
 
         /// <inheritdoc />
         public virtual NamingStrategy NamingStrategy { 
-        get
+            get
             { 
-                switch (this._configOptions.NamingStrategy)
-                {
-                    case NamingStrategyType.CamelCase:
-                        return new CamelCaseNamingStrategy();
-                    case NamingStrategyType.PascalCase:
-                        return new DefaultNamingStrategy();
-                    case NamingStrategyType.SnakeCase:
-                        return new SnakeCaseNamingStrategy();
-                    case NamingStrategyType.KebabCase:
-                        return new KebabCaseNamingStrategy();
-                    default:
-                        return new CamelCaseNamingStrategy();
-                }
+                return OpenApiConfigurationResolver.Resolve(this._configOptions.OpenApiNamingStrategy);
             }
         }
-
         /// <inheritdoc />
         public virtual bool IsDevelopment { get; } = Environment.GetEnvironmentVariable("AZURE_FUNCTIONS_ENVIRONMENT") == "Development";
 

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/OpenApiHttpTriggerContext.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/OpenApiHttpTriggerContext.cs
@@ -129,7 +129,24 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi
         public virtual ISwaggerUI SwaggerUI { get; }
 
         /// <inheritdoc />
-        public virtual NamingStrategy NamingStrategy { get; } = new CamelCaseNamingStrategy();
+        public virtual NamingStrategy NamingStrategy { 
+        get
+            { 
+                switch (this._configOptions.NamingStrategy)
+                {
+                    case NamingStrategyType.CamelCase:
+                        return new CamelCaseNamingStrategy();
+                    case NamingStrategyType.PascalCase:
+                        return new DefaultNamingStrategy();
+                    case NamingStrategyType.SnakeCase:
+                        return new SnakeCaseNamingStrategy();
+                    case NamingStrategyType.KebabCase:
+                        return new KebabCaseNamingStrategy();
+                    default:
+                        return new CamelCaseNamingStrategy();
+                }
+            }
+        }
 
         /// <inheritdoc />
         public virtual bool IsDevelopment { get; } = Environment.GetEnvironmentVariable("AZURE_FUNCTIONS_ENVIRONMENT") == "Development";

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IOpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Abstractions/IOpenApiConfigurationOptions.cs
@@ -49,5 +49,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions
         /// Gets or sets the <see cref="IOpenApiHttpTriggerAuthorization"/> instance for Swagger endpoints.
         /// </summary>
         IOpenApiHttpTriggerAuthorization Security { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating OpenApiNamingStrategy.
+        /// </summary>
+        OpenApiNamingStrategy OpenApiNamingStrategy { get; set; } 
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
@@ -212,10 +212,5 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
 
             return development;
         }
-
-        private static OpenApiNamingStrategy DefaultOpenApiNamingStrategy()
-        {
-            return OpenApiNamingStrategy.CamelCase;
-        }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
@@ -167,12 +167,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
             return forceHttps;
         }
 
+        /// <summary>
+        /// Gets the OpenAPI NamingStrategy.
+        /// </summary>
+        /// <returns>Returns the OpenAPI NamingStrategy.</returns>
         public static OpenApiNamingStrategy GetOpenApiNamingStrategy()
         {
             var result = Enum.TryParse<OpenApiNamingStrategy>(
                                 Environment.GetEnvironmentVariable(OpenApiNamingStrategyKey));
             return result ? result : DefaultOpenApiNamingStrategy();
         }
+        
         private static OpenApiVersionType DefaultOpenApiVersion()
         {
             return OpenApiVersionType.V2;
@@ -198,6 +203,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
             var development = Environment.GetEnvironmentVariable(FunctionsRuntimeEnvironmentKey) == "Development";
 
             return development;
+        }
+
+        private static OpenApiNamingStrategy DefaultOpenApiNamingStrategy()
+        {
+            return OpenApiNamingStrategy.CamelCase;
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
         private const string ExcludeRequestingHostKey = "OpenApi__ExcludeRequestingHost";
         private const string ForceHttpKey = "OpenApi__ForceHttp";
         private const string ForceHttpsKey = "OpenApi__ForceHttps";
+        private const string OpenApiNamingStrategyKey = "OpenApi__NamingStrategy";
 
         /// <inheritdoc />
         public override OpenApiInfo Info { get; set; } = new OpenApiInfo()
@@ -54,6 +55,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
 
         /// <inheritdoc />
         public override IOpenApiHttpTriggerAuthorization Security { get; set; } = new DefaultOpenApiHttpTriggerAuthorization();
+
+        /// <inheritdoc />
+        public override OpenApiNamingStrategy OpenApiNamingStrategy { get; set; } = GetOpenApiNamingStrategy();
 
         /// <summary>
         /// Gets the OpenAPI document version.
@@ -163,6 +167,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
             return forceHttps;
         }
 
+        public static OpenApiNamingStrategy GetOpenApiNamingStrategy()
+        {
+            var result = Enum.TryParse<OpenApiNamingStrategy>(
+                                Environment.GetEnvironmentVariable(OpenApiNamingStrategyKey));
+            return result ? result : DefaultOpenApiNamingStrategy();
+        }
         private static OpenApiVersionType DefaultOpenApiVersion()
         {
             return OpenApiVersionType.V2;

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
@@ -21,11 +21,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
         private const string OpenApiDocDescriptionKey = "OpenApi__DocDescription";
         private const string OpenApiHostNamesKey = "OpenApi__HostNames";
         private const string OpenApiVersionKey = "OpenApi__Version";
+        private const string OpenApiNamingStrategyKey = "OpenApi__NamingStrategy";
         private const string FunctionsRuntimeEnvironmentKey = "AZURE_FUNCTIONS_ENVIRONMENT";
         private const string ExcludeRequestingHostKey = "OpenApi__ExcludeRequestingHost";
         private const string ForceHttpKey = "OpenApi__ForceHttp";
         private const string ForceHttpsKey = "OpenApi__ForceHttps";
-        private const string OpenApiNamingStrategyKey = "OpenApi__NamingStrategy";
 
         /// <inheritdoc />
         public override OpenApiInfo Info { get; set; } = new OpenApiInfo()
@@ -129,6 +129,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
         }
 
         /// <summary>
+        /// Gets the OpenAPI NamingStrategy.
+        /// </summary>
+        /// <returns>Returns the OpenAPI NamingStrategy.</returns>
+        public static OpenApiNamingStrategy GetOpenApiNamingStrategy()
+        {
+            var strategy = Enum.TryParse<OpenApiNamingStrategy>(
+                                Environment.GetEnvironmentVariable(OpenApiNamingStrategyKey), ignoreCase: true, out var result)
+                                ? result
+                                : DefaultOpenApiNamingStrategy();
+            
+            return strategy;
+        }
+
+        /// <summary>
         /// Checks whether to exclude the requesting host as the server URL or not.
         /// </summary>
         /// <returns>Returns <c>True</c>, if the requesting host is excluded; otherwise returns <c>False</c></returns>
@@ -167,17 +181,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
             return forceHttps;
         }
 
-        /// <summary>
-        /// Gets the OpenAPI NamingStrategy.
-        /// </summary>
-        /// <returns>Returns the OpenAPI NamingStrategy.</returns>
-        public static OpenApiNamingStrategy GetOpenApiNamingStrategy()
-        {
-            var result = Enum.TryParse<OpenApiNamingStrategy>(
-                                Environment.GetEnvironmentVariable(OpenApiNamingStrategyKey));
-            return result ? result : DefaultOpenApiNamingStrategy();
-        }
-        
         private static OpenApiVersionType DefaultOpenApiVersion()
         {
             return OpenApiVersionType.V2;
@@ -186,6 +189,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
         private static string DefaultOpenApiDocVersion()
         {
             return "1.0.0";
+        }
+
+        private static OpenApiNamingStrategy DefaultOpenApiNamingStrategy()
+        {
+            return OpenApiNamingStrategy.CamelCase;
         }
 
         private static string DefaultOpenApiDocTitle()

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiConfigurationOptions.cs
@@ -40,7 +40,5 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
         /// <inheritdoc />
         public virtual IOpenApiHttpTriggerAuthorization Security { get; set; } = new OpenApiHttpTriggerAuthorization();
 
-        /// <inheritdoc />
-        public virtual OpenApiNamingStrategy OpenApiNamingStrategy { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiConfigurationOptions.cs
@@ -36,5 +36,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
 
         /// <inheritdoc />
         public virtual IOpenApiHttpTriggerAuthorization Security { get; set; } = new OpenApiHttpTriggerAuthorization();
+
+        /// <inheritdoc />
+        public virtual OpenApiNamingStrategy OpenApiNamingStrategy { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/OpenApiConfigurationOptions.cs
@@ -23,6 +23,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
         public virtual OpenApiVersionType OpenApiVersion { get; set; }
 
         /// <inheritdoc />
+        public virtual OpenApiNamingStrategy OpenApiNamingStrategy { get; set; }
+
+        /// <inheritdoc />
         public virtual bool ExcludeRequestingHost { get; set; }
 
         /// <inheritdoc />

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Enums/OpenApiNamingStrategy.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Enums/OpenApiNamingStrategy.cs
@@ -1,0 +1,28 @@
+namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums
+{
+    /// <summary>
+    /// This specifies the naming strategy for OpenAPI.
+    /// </summary>
+    public enum OpenApiNamingStrategy
+    {
+        /// <summary>
+        /// Identifies the default naming strategy.
+        /// </summary>
+        CamelCase = 0,
+
+        /// <summary>
+        /// Identifies the PascalCase naming strategy.
+        /// </summary>
+        PascalCase = 1,
+
+        /// <summary>
+        /// Identifies the snake_case naming strategy.
+        /// </summary>
+        SnakeCase = 2,
+
+        /// <summary>
+        /// Identifies the kebab-case naming strategy.
+        /// </summary>
+        KebabCase = 3
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Resolvers/OpenApiConfigurationResolver.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Resolvers/OpenApiConfigurationResolver.cs
@@ -5,8 +5,10 @@ using System.Reflection;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.OpenApi.Models;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Resolvers
 {
@@ -41,18 +43,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Resolvers
         /// Gets the <see cref="IOpenApiConfigurationOptions"/> instance from the given strategyType.
         /// </summary>
         /// <param name="strategyType">The naming strategy type.</param>
-        /// <returns>Returns the NamingStrategy instance resolved.(Overload)</returns>
-        public static NamingStrategy Resolve(NamingStrategyType strategyType)
+        /// <returns>Returns the NamingStrategy instance resolved.(Override)</returns>
+        public static NamingStrategy Resolve(OpenApiNamingStrategy strategyType)
         {
             switch (strategyType)
             {
-                case NamingStrategyType.CamelCase:
+                case OpenApiNamingStrategy.CamelCase:
                     return new CamelCaseNamingStrategy();
-                case NamingStrategyType.PascalCase:
+                case OpenApiNamingStrategy.PascalCase:
                     return new DefaultNamingStrategy();
-                case NamingStrategyType.SnakeCase:
+                case OpenApiNamingStrategy.SnakeCase:
                     return new SnakeCaseNamingStrategy();
-                case NamingStrategyType.KebabCase:
+                case OpenApiNamingStrategy.KebabCase:
                     return new KebabCaseNamingStrategy();
                 default:
                     return new CamelCaseNamingStrategy();

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Resolvers/OpenApiConfigurationResolver.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Resolvers/OpenApiConfigurationResolver.cs
@@ -36,5 +36,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Resolvers
 
             return options as IOpenApiConfigurationOptions;
         }
+    
+        /// <summary>
+        /// Gets the <see cref="IOpenApiConfigurationOptions"/> instance from the given strategyType.
+        /// </summary>
+        /// <param name="strategyType">The naming strategy type.</param>
+        /// <returns>Returns the NamingStrategy instance resolved.(Override)</returns>
+        public static NamingStrategy Resolve(NamingStrategyType strategyType)
+        {
+            switch (strategyType)
+            {
+                case NamingStrategyType.CamelCase:
+                    return new CamelCaseNamingStrategy();
+                case NamingStrategyType.PascalCase:
+                    return new DefaultNamingStrategy();
+                case NamingStrategyType.SnakeCase:
+                    return new SnakeCaseNamingStrategy();
+                case NamingStrategyType.KebabCase:
+                    return new KebabCaseNamingStrategy();
+                default:
+                    return new CamelCaseNamingStrategy();
+            }
+        }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Resolvers/OpenApiConfigurationResolver.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Resolvers/OpenApiConfigurationResolver.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Resolvers
         /// Gets the <see cref="IOpenApiConfigurationOptions"/> instance from the given strategyType.
         /// </summary>
         /// <param name="strategyType">The naming strategy type.</param>
-        /// <returns>Returns the NamingStrategy instance resolved.(Override)</returns>
+        /// <returns>Returns the NamingStrategy instance resolved.(Overload)</returns>
         public static NamingStrategy Resolve(NamingStrategyType strategyType)
         {
             switch (strategyType)

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiHttpTriggerContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiHttpTriggerContext.cs
@@ -131,10 +131,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
         public virtual NamingStrategy NamingStrategy { 
             get
             { 
-                return OpenApiConfigurationResolver.Resolve(this._configOptions.NamingStrategy);
+                return OpenApiConfigurationResolver.Resolve(this._configOptions.OpenApiNamingStrategy);
             }
         }
-
         /// <inheritdoc />
         public virtual bool IsDevelopment { get; } = Environment.GetEnvironmentVariable("AZURE_FUNCTIONS_ENVIRONMENT") == "Development";
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiHttpTriggerContext.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi/OpenApiHttpTriggerContext.cs
@@ -128,7 +128,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi
         public virtual ISwaggerUI SwaggerUI { get; }
 
         /// <inheritdoc />
-        public virtual NamingStrategy NamingStrategy { get; } = new CamelCaseNamingStrategy();
+        public virtual NamingStrategy NamingStrategy { 
+            get
+            { 
+                return OpenApiConfigurationResolver.Resolve(this._configOptions.NamingStrategy);
+            }
+        }
 
         /// <inheritdoc />
         public virtual bool IsDevelopment { get; } = Environment.GetEnvironmentVariable("AZURE_FUNCTIONS_ENVIRONMENT") == "Development";

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/OpenApiHttpTriggerContextTests.cs
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests/OpenApiHttpTriggerContextTests.cs
@@ -12,7 +12,7 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
-
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Resolvers;
 using Microsoft.OpenApi;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -32,6 +32,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
             Environment.SetEnvironmentVariable("OpenApi__AuthLevel__Document", null);
             Environment.SetEnvironmentVariable("OpenApi__AuthLevel__UI", null);
             Environment.SetEnvironmentVariable("OpenApi__ApiKey", null);
+            Environment.SetEnvironmentVariable("OpenApi__NamingStrategy",null);
         }
 
         [DataTestMethod]
@@ -191,16 +192,51 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
         }
 
         [TestMethod]
-        public async Task Given_Type_When_Initiated_Then_It_Should_Return_NamingStrategy()
+        public async Task Given_NoType_When_Initiated_Then_It_Should_Return_NamingStrategy()
         {
             var location = new FileInfo(Assembly.GetExecutingAssembly().Location).Directory.FullName;
             var context = new OpenApiHttpTriggerContext();
 
-            var namingStrategy = (await context.SetApplicationAssemblyAsync(location, false))
-                                         .NamingStrategy;
+            var namingStrategy = OpenApiConfigurationResolver.Resolve((await context.SetApplicationAssemblyAsync(location, false))
+                                         .OpenApiConfigurationOptions.OpenApiNamingStrategy);
 
             namingStrategy.Should().NotBeNull();
             namingStrategy.Should().BeOfType<CamelCaseNamingStrategy>();
+        }
+
+        [TestMethod]
+        public async Task Given_UnvaildType_When_Initiated_Then_It_Should_Return_NamingStrategy()
+        {
+            Environment.SetEnvironmentVariable("OpenApi__NamingStrategy", "hello");
+
+            var location = new FileInfo(Assembly.GetExecutingAssembly().Location).Directory.FullName;
+            var context = new OpenApiHttpTriggerContext();
+
+            var namingStrategy = OpenApiConfigurationResolver.Resolve((await context.SetApplicationAssemblyAsync(location, false))
+                                            .OpenApiConfigurationOptions.OpenApiNamingStrategy);
+            
+            namingStrategy.Should().NotBeNull();
+            namingStrategy.Should().BeOfType<CamelCaseNamingStrategy>();
+        }
+
+        [DataTestMethod]
+        [DataRow("CamelCase", "CamelCaseNamingStrategy")]
+        [DataRow("PascalCase", "DefaultNamingStrategy")]
+        [DataRow("SnakeCase", "SnakeCaseNamingStrategy")]
+        [DataRow("KebabCase", "KebabCaseNamingStrategy")]
+        public async Task Given_Type_When_Initiated_Then_It_Should_Return_NamingStrategy(string strategy, string expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__NamingStrategy", strategy);
+
+            var location = new FileInfo(Assembly.GetExecutingAssembly().Location).Directory.FullName;
+            var context = new OpenApiHttpTriggerContext();
+
+            var namingStrategy = OpenApiConfigurationResolver.Resolve((await context.SetApplicationAssemblyAsync(location, false))
+                                         .OpenApiConfigurationOptions.OpenApiNamingStrategy);
+            
+            namingStrategy.Should().NotBeNull();
+            namingStrategy.GetType().Name.Should().Be(expected);            
+
         }
 
         [DataTestMethod]
@@ -224,7 +260,8 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Tests
             var location = new FileInfo(Assembly.GetExecutingAssembly().Location).Directory.FullName;
             var req = new Mock<IHttpRequestDataObject>();
 
-            var res = new OpenApiAuthorizationResult()
+            var res = new OpenApiAuthorizationResult()
+
             {
                 StatusCode = FakeOpenApiHttpTriggerAuthorization.StatusCode,
                 ContentType = FakeOpenApiHttpTriggerAuthorization.ContentType,

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/DefaultOpenApiConfigurationOptionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/DefaultOpenApiConfigurationOptionsTests.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
             Environment.SetEnvironmentVariable("OpenApi__ExcludeRequestingHost", null);
             Environment.SetEnvironmentVariable("OpenApi__ForceHttp", null);
             Environment.SetEnvironmentVariable("OpenApi__ForceHttps", null);
+            Environment.SetEnvironmentVariable("OpenApi__NamingStrategy", "CamelCase");
         }
 
         [TestMethod]
@@ -266,6 +267,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
             var result = DefaultOpenApiConfigurationOptions.IsHttpForced();
 
             result.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, OpenApiNamingStrategy.CamelCase)]
+        [DataRow("PascalCase", OpenApiNamingStrategy.PascalCase)]
+        [DataRow("SnakeCase", OpenApiNamingStrategy.SnakeCase)]
+        [DataRow("KebabCase", OpenApiNamingStrategy.KebabCase)]
+        public void Given_EnvironmentVariable_When_GetOpenApiNamingStrategy_Invoked_Then_It_Should_Return_Result(string type, OpenApiNamingStrategy expected)
+        {
+            Environment.SetEnvironmentVariable("OpenApi__NamingStrategy", type); 
+
+            var result = DefaultOpenApiConfigurationOptions.GetOpenApiNamingStrategy();
+
+            result.Should().Be(expected); 
         }
 
         [DataTestMethod]

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/OpenApiConfigurationOptionsTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Configurations/OpenApiConfigurationOptionsTests.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Configurations
 
             options.Security.Should().NotBeNull();
             options.Security.Should().BeOfType<OpenApiHttpTriggerAuthorization>();
+
+            options.OpenApiNamingStrategy.Should().Be(OpenApiNamingStrategy.CamelCase);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Resolvers/OpenApiConfigurationResolverTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Resolvers/OpenApiConfigurationResolverTests.cs
@@ -51,5 +51,86 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Resolvers
             result.Should().BeOfType<FakeOpenApiConfigurationOptions>();
             result.GetType().BaseType.Should().Be(typeof(FakeOpenApiConfigurationOptionsBase)); // This verifies the abstract type was considered in the resolution
         }
+
+        /// <summary>
+        /// This tests are added to cover the switch statement in the Resolve method.
+        /// </summary>
+        [TestMethod]
+        public void Given_CamelCase_When_Resolve_Invoked_Then_It_Should_Return_CamelCaseNamingStrategy()
+        {
+            var strategyType = NamingStrategyType.CamelCase;
+
+            var result = OpenApiConfigurationResolver.Resolve(strategyType);
+
+            result.Should().BeOfType<CamelCaseNamingStrategy>();
+        }
+
+        [TestMethod]
+        public void Given_PascalCase_When_Resolve_Invoked_Then_It_Should_Return_DefaultNamingStrategy()
+        {
+            var strategyType = NamingStrategyType.PascalCase;
+
+            var result = OpenApiConfigurationResolver.Resolve(strategyType);
+
+            result.Should().BeOfType<DefaultNamingStrategy>();
+        }
+
+        [TestMethod]
+        public void Given_SnakeCase_When_Resolve_Invoked_Then_It_Should_Return_SnakeCaseNamingStrategy()
+        {
+            var strategyType = NamingStrategyType.SnakeCase;
+
+            var result = OpenApiConfigurationResolver.Resolve(strategyType);
+
+            result.Should().BeOfType<SnakeCaseNamingStrategy>();
+        }
+
+        [TestMethod]
+        public void Given_KebabCase_When_Resolve_Invoked_Then_It_Should_Return_KebabCaseNamingStrategy()
+        {
+            var strategyType = NamingStrategyType.KebabCase;
+
+            var result = OpenApiConfigurationResolver.Resolve(strategyType);
+
+            result.Should().BeOfType<KebabCaseNamingStrategy>();
+        }
+
+        [TestMethod]
+        public void Given_SnakeCase_number_When_Resolve_Invoked_Then_It_Should_Return_SnakeCaseNamingStrategy()
+        {
+            var strategyType = (NamingStrategyType)2; 
+
+            var result = OpenApiConfigurationResolver.Resolve(strategyType);
+
+            result.Should().BeOfType<SnakeCaseNamingStrategy>();
+        }
+
+        [TestMethod]
+        public void Given_UnexpectedValue_When_Resolve_Invoked_Then_It_Should_Return_CamelCaseNamingStrategy()
+        {
+            var strategyType = (NamingStrategyType)999; 
+
+            var result = OpenApiConfigurationResolver.Resolve(strategyType);
+
+            result.Should().BeOfType<CamelCaseNamingStrategy>();
+        }
+
+
+        [TestMethod]
+        public void Given_Null_When_Resolve_Invoked_Then_It_Should_Return_CamelCaseNamingStrategy()
+        {
+            var result = OpenApiConfigurationResolver.Resolve(null);
+
+            result.Should().BeOfType<CamelCaseNamingStrategy>();
+        }
+
+        [TestMethod]
+        public void Given_Null_When_Resolve_Invoked_Then_It_Should_Return_DefaultOpenApiConfigurationOptions()
+        {
+            var result = OpenApiConfigurationResolver.Resolve(null);
+
+            result.Should().BeOfType<DefaultOpenApiConfigurationOptions>();
+        }
+
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Resolvers/OpenApiConfigurationResolverTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Resolvers/OpenApiConfigurationResolverTests.cs
@@ -117,22 +117,5 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Resolvers
             result.Should().BeOfType<CamelCaseNamingStrategy>();
         }
 
-
-        [TestMethod]
-        public void Given_Null_When_Resolve_Invoked_Then_It_Should_Return_CamelCaseNamingStrategy()
-        {
-            var result = OpenApiConfigurationResolver.Resolve(null);
-
-            result.Should().BeOfType<CamelCaseNamingStrategy>();
-        }
-
-        [TestMethod]
-        public void Given_Null_When_Resolve_Invoked_Then_It_Should_Return_DefaultOpenApiConfigurationOptions()
-        {
-            var result = OpenApiConfigurationResolver.Resolve(null);
-
-            result.Should().BeOfType<DefaultOpenApiConfigurationOptions>();
-        }
-
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Resolvers/OpenApiConfigurationResolverTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Resolvers/OpenApiConfigurationResolverTests.cs
@@ -3,10 +3,12 @@ using System.Reflection;
 using FluentAssertions;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Resolvers;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Fakes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Resolvers
 {
@@ -58,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Resolvers
         [TestMethod]
         public void Given_CamelCase_When_Resolve_Invoked_Then_It_Should_Return_CamelCaseNamingStrategy()
         {
-            var strategyType = NamingStrategyType.CamelCase;
+            var strategyType = OpenApiNamingStrategy.CamelCase;
 
             var result = OpenApiConfigurationResolver.Resolve(strategyType);
 
@@ -68,7 +70,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Resolvers
         [TestMethod]
         public void Given_PascalCase_When_Resolve_Invoked_Then_It_Should_Return_DefaultNamingStrategy()
         {
-            var strategyType = NamingStrategyType.PascalCase;
+            var strategyType = OpenApiNamingStrategy.PascalCase;
 
             var result = OpenApiConfigurationResolver.Resolve(strategyType);
 
@@ -78,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Resolvers
         [TestMethod]
         public void Given_SnakeCase_When_Resolve_Invoked_Then_It_Should_Return_SnakeCaseNamingStrategy()
         {
-            var strategyType = NamingStrategyType.SnakeCase;
+            var strategyType = OpenApiNamingStrategy.SnakeCase;
 
             var result = OpenApiConfigurationResolver.Resolve(strategyType);
 
@@ -88,7 +90,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Resolvers
         [TestMethod]
         public void Given_KebabCase_When_Resolve_Invoked_Then_It_Should_Return_KebabCaseNamingStrategy()
         {
-            var strategyType = NamingStrategyType.KebabCase;
+            var strategyType = OpenApiNamingStrategy.KebabCase;
 
             var result = OpenApiConfigurationResolver.Resolve(strategyType);
 
@@ -98,7 +100,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Resolvers
         [TestMethod]
         public void Given_SnakeCase_number_When_Resolve_Invoked_Then_It_Should_Return_SnakeCaseNamingStrategy()
         {
-            var strategyType = (NamingStrategyType)2; 
+            var strategyType = (OpenApiNamingStrategy)2; 
 
             var result = OpenApiConfigurationResolver.Resolve(strategyType);
 
@@ -108,7 +110,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Resolvers
         [TestMethod]
         public void Given_UnexpectedValue_When_Resolve_Invoked_Then_It_Should_Return_CamelCaseNamingStrategy()
         {
-            var strategyType = (NamingStrategyType)999; 
+            var strategyType = (OpenApiNamingStrategy)999; 
 
             var result = OpenApiConfigurationResolver.Resolve(strategyType);
 


### PR DESCRIPTION
#485
We add new option for setting to namingstrategy.

1. IOpenApiConfigurationOptions
2. OpenApiConfigurationOptions
3. DefaultApiConfiguationOptions
4. Enum : OpenApiNamingStrategy
5. Workers.OpenApiHttpTriggerContext
6. Webjobs.OpenApiHttpTriggerContext
7. Unit Tests

One Strange Thing is OpenApiHttpTriggerContextTests, we only add unit tests for namingstrategy,,
but, github judged all thing is changed.
So, We mention what has changed.



        [TestMethod]
        public async Task Given_NoType_When_Initiated_Then_It_Should_Return_NamingStrategy()
        {
            var location = new FileInfo(Assembly.GetExecutingAssembly().Location).Directory.FullName;
            var context = new OpenApiHttpTriggerContext();

            var namingStrategy = OpenApiConfigurationResolver.Resolve((await context.SetApplicationAssemblyAsync(location, false))
                                         .OpenApiConfigurationOptions.OpenApiNamingStrategy);

            namingStrategy.Should().NotBeNull();
            namingStrategy.Should().BeOfType<CamelCaseNamingStrategy>();
        }

        [TestMethod]
        public async Task Given_UnvaildType_When_Initiated_Then_It_Should_Return_NamingStrategy()
        {
            Environment.SetEnvironmentVariable("OpenApi__NamingStrategy", "hello");

            var location = new FileInfo(Assembly.GetExecutingAssembly().Location).Directory.FullName;
            var context = new OpenApiHttpTriggerContext();

            var namingStrategy = OpenApiConfigurationResolver.Resolve((await context.SetApplicationAssemblyAsync(location, false))
                                            .OpenApiConfigurationOptions.OpenApiNamingStrategy);
            
            namingStrategy.Should().NotBeNull();
            namingStrategy.Should().BeOfType<CamelCaseNamingStrategy>();
        }

        [DataTestMethod]
        [DataRow("CamelCase", "CamelCaseNamingStrategy")]
        [DataRow("PascalCase", "DefaultNamingStrategy")]
        [DataRow("SnakeCase", "SnakeCaseNamingStrategy")]
        [DataRow("KebabCase", "KebabCaseNamingStrategy")]
        public async Task Given_Type_When_Initiated_Then_It_Should_Return_NamingStrategy(string strategy, string expected)
        {
            Environment.SetEnvironmentVariable("OpenApi__NamingStrategy", strategy);

            var location = new FileInfo(Assembly.GetExecutingAssembly().Location).Directory.FullName;
            var context = new OpenApiHttpTriggerContext();

            var namingStrategy = OpenApiConfigurationResolver.Resolve((await context.SetApplicationAssemblyAsync(location, false))
                                         .OpenApiConfigurationOptions.OpenApiNamingStrategy);
            
            namingStrategy.Should().NotBeNull();
            namingStrategy.GetType().Name.Should().Be(expected);            

        }
`