### PR TITLE
fix #626

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/MemberInfoExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/MemberInfoExtensions.cs
@@ -24,9 +24,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions
         {
             element.ThrowIfNullOrDefault();
 
-            var exists = element.GetCustomAttribute<T>(inherit) != null;
-
-            return exists;
+            try
+            {
+                var exists = element.GetCustomAttribute<T>(inherit) != null;
+                return exists;
+            }
+            catch (System.IO.FileNotFoundException)
+            {
+                return false;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This addresses the #626 so the behavior of `Microsoft.Azure.Functions.Worker.Extensions.OpenApi` matches `Microsoft.Azure.WebJobs.Extensions.OpenApi`.

After the change I could confirm the migrated project can safely skip attempting to load unused types.