### PR TITLE
Update enable-open-api-endpoints-out-of-proc.md

### DIFF
--- a/docs/enable-open-api-endpoints-out-of-proc.md
+++ b/docs/enable-open-api-endpoints-out-of-proc.md
@@ -99,11 +99,11 @@ namespace MyOpenApiFunctionApp
         {
             var host = new HostBuilder()
             // Remove this line below
-                .ConfigureFunctionsWorkerDefaults()
+                .ConfigureFunctionsWebApplication()
             // Remove this line above
 
             // Add these lines below
-                .ConfigureFunctionsWorkerDefaults(worker => worker.UseNewtonsoftJson())
+                .ConfigureFunctionsWebApplication(worker => worker.UseNewtonsoftJson())
             // Add these lines above
                 .Build();
 


### PR DESCRIPTION
The new  HTTPtrigger function uses ConfigureFunctionsWebApplication as a default