### PR TITLE
Fix bug that causes the configuration version to go out of enum bounds when reading from environment

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Configurations/DefaultOpenApiConfigurationOptions.cs
@@ -112,8 +112,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations
         /// <returns>Returns the OpenAPI version.</returns>
         public static OpenApiVersionType GetOpenApiVersion()
         {
-            var version = Enum.TryParse<OpenApiVersionType>(
-                              Environment.GetEnvironmentVariable(OpenApiVersionKey), ignoreCase: true, out var result)
+            var version = Enum.TryParse<OpenApiVersionType>(Environment.GetEnvironmentVariable(OpenApiVersionKey),
+                              ignoreCase: true, out var result)
+                          && Enum.IsDefined(typeof(OpenApiVersionType), result)
                             ? result
                             : DefaultOpenApiVersion();
 


### PR DESCRIPTION
**Short Description**: This PR fixes a bug that causes the property "version" in the default configuration to go out of enum bounds, caused by a missing enum validation.


**Bug**: If you input a single integer as a value for the environment variable: "OpenApi__Version", the integer slips into the property, despite being out of enum bounds.


**Reproduction**: Use this as an environment variable before running: "OpenApi__Version=3"


**Consequence:** Error in the SwaggerUI when rendering, because /api/swagger.json throws exception.

![image](https://github.com/user-attachments/assets/b1f0130e-6707-4e99-9bac-c1c921553cf3)


**Stack-Trace when calling /api/swagger.json:**
```
Invalid OpenAPI version

   at Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions.OpenApiDocumentExtensions.Serialise(OpenApiDocument document, TextWriter writer, OpenApiSpecVersion version, OpenApiFormat format) in /Users/<user>/Code/azure-functions-openapi-extension/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Extensions/OpenApiDocumentExtensions.cs:line 40
   at Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Document.Render(OpenApiSpecVersion version, OpenApiFormat format) in /Users/<user>/Code/azure-functions-openapi-extension/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Document.cs:line 245
   at Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Document.<>c__DisplayClass18_0.<RenderAsync>b__0() in /Users/<user>/Code/azure-functions-openapi-extension/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Document.cs:line 220
   at System.Threading.Tasks.Task`1.InnerInvoke()
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
--- End of stack trace from previous location ---
   at Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Document.RenderAsync(OpenApiSpecVersion version, OpenApiFormat format) in /Users/<user>/Code/azure-functions-openapi-extension/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Document.cs:line 219
   at Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Functions.OpenApiTriggerFunction.RenderSwaggerDocument(HttpRequestData req, String extension, FunctionContext ctx) in /Users/<user>/Code/azure-functions-openapi-extension/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi/Functions/OpenApiTriggerFunction.cs:line 59
```


**Reason**: 
Excerpt from the method documentation of Enum.TryParse<>():
> result — When this method returns, result contains an object of type TEnum whose value is represented by value if the parse operation succeeds. If the parse operation fails, result contains the default value of the underlying type of TEnum. **<ins>Note that this value need not be a member of the TEnum enumeration.</ins>** This parameter is passed uninitialized. 


### **<ins>Fix</ins>**: Validate the enum value and fallback to version 2, if out of bounds.
