### PR TITLE
Nested generic types support

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/BaseObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/BaseObjectTypeVisitor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.OpenApi.Models;
 
 using Newtonsoft.Json.Serialization;
@@ -31,11 +32,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
         /// <inheritdoc />
         public override void Visit(IAcceptor acceptor, KeyValuePair<string, Type> type, NamingStrategy namingStrategy, params Attribute[] attributes)
         {
-            var title = type.Value.IsGenericType
-                ? namingStrategy.GetPropertyName(type.Value.Name.Split('`').First(), hasSpecifiedName: false) + "_" +
-                  string.Join("_",
-                      type.Value.GenericTypeArguments.Select(a => namingStrategy.GetPropertyName(a.Name, false)))
-                : namingStrategy.GetPropertyName(type.Value.Name, hasSpecifiedName: false);
+            var title = type.Value.GetOpenApiTypeName(namingStrategy);
             this.Visit(acceptor, name: type.Key, title: title, dataType: "object", dataFormat: null, attributes: attributes);
         }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
@@ -90,11 +90,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
         /// <inheritdoc />
         public override void Visit(IAcceptor acceptor, KeyValuePair<string, Type> type, NamingStrategy namingStrategy, params Attribute[] attributes)
         {
-            var title = type.Value.IsGenericType
-                ? namingStrategy.GetPropertyName(type.Value.Name.Split('`').First(), hasSpecifiedName: false) + "_" +
-                  string.Join("_",
-                      type.Value.GenericTypeArguments.Select(a => namingStrategy.GetPropertyName(a.Name, false)))
-                : namingStrategy.GetPropertyName(type.Value.Name, hasSpecifiedName: false);
+            var title = type.Value.GetOpenApiTypeName(namingStrategy);
             var name = this.Visit(acceptor, name: type.Key, title: title, dataType: "object", dataFormat: null, attributes: attributes);
 
             if (name.IsNullOrWhiteSpace())

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DictionaryObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/DictionaryObjectTypeVisitorTests.cs
@@ -91,10 +91,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
         [DataRow(typeof(IReadOnlyDictionary<string, string>), "object", null, "string", false, "string", 0)]
         [DataRow(typeof(KeyValuePair<string, string>), "object", null, "string", false, "string", 0)]
         [DataRow(typeof(Dictionary<string, FakeModel>), "object", null, "object", true, "fakeModel", 1)]
-        [DataRow(typeof(Dictionary<string, string[]>), "object", null, "array", true, "list_string", 1)] //
+        [DataRow(typeof(Dictionary<string, string[]>), "object", null, "array", true, "list_string", 1)]
         [DataRow(typeof(IDictionary<string, FakeModel>), "object", null, "object", true, "fakeModel", 1)]
         [DataRow(typeof(IReadOnlyDictionary<string, FakeModel>), "object", null, "object", true, "fakeModel", 1)]
         [DataRow(typeof(KeyValuePair<string, FakeModel>), "object", null, "object", true, "fakeModel", 1)]
+        [DataRow(typeof(KeyValuePair<string, List<FakeGenericModel<FakeModel>>>), "object", null, "array", true, "list_fakeGenericModel_fakeModel", 1)]
         public void Given_Type_When_Visit_Invoked_Then_It_Should_Return_Result(Type dictionaryType, string dataType, string dataFormat, string additionalPropertyType, bool isReferential, string referenceId, int expected)
         {
             var name = "hello";

--- a/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/ObjectTypeVisitorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests/Visitors/ObjectTypeVisitorTests.cs
@@ -88,6 +88,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Tests.Visitors
         [DataRow(typeof(FakeModel), "object", null, 3, 3, "fakeModel")]
         [DataRow(typeof(FakeRequiredModel), "object", null, 1, 0, "fakeRequiredModel")]
         [DataRow(typeof(FakeRecursiveModel), "object", null, 3, 2, "fakeRecursiveModel")]
+        [DataRow(typeof(FakeGenericModel<List<FakeModel>>), "object", null, 0, 4, "fakeGenericModel_list_fakeModel")]
         public void Given_Type_When_Visit_Invoked_Then_It_Should_Return_Result(Type objectType, string dataType, string dataFormat, int requiredCount, int rootSchemaCount, string referenceId)
         {
             var name = "hello";


### PR DESCRIPTION
Nested generic types are generated into correct ReferenceId without inverted comma in name:

Expected acceptor.Schemas[name].Reference.Id to be 
"fakeGenericModel_list_fakeModel" with a length of 31, but 
"fakeGenericModel_list`1" has a length of 23, differs near "`1" (index 21).


Expected acceptor.Schemas[name].AdditionalProperties.Reference.Id to be 
"list_fakeGenericModel_fakeModel" with a length of 31, but 
"list_fakeGenericModel`1" has a length of 23, differs near "`1" (index 21).
