### PR TITLE
Update ObjectTypeVisitor

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.OpenApi.Core/Visitors/ObjectTypeVisitor.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Visitors
 
             // Adds schemas to the root.
             var schemasToBeAdded = subAcceptor.Schemas
-                                              .Where(p => !instance.Schemas.Keys.Contains(p.Key))
+                                              .Where(p => !(instance.Schemas.Keys.Contains(p.Key) && instance.Schemas[p.Key].Type == p.Value.Type)) 
                                               .Where(p => p.Value.IsOpenApiSchemaObject())
                                               .GroupBy(p => p.Value.Title)
                                               .Select(p => p.First())


### PR DESCRIPTION
Update ObjectTypeVisitor.cs - Swagger is not being generated when 2 properties are named the same in the JSON with different property parents.