### PR TITLE
Add build-time OpenAPI document generator for isolated-worker apps

### DIFF
--- a/Microsoft.Azure.WebJobs.Extensions.OpenApi.sln
+++ b/Microsoft.Azure.WebJobs.Extensions.OpenApi.sln
@@ -52,6 +52,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Ext
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests", "test-integration\Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests\Microsoft.Azure.WebJobs.Extensions.OpenApi.Document.Tests.csproj", "{8324C8D1-A9FD-4F98-8ED9-82C3BE572DBB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator", "src\Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator\Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.csproj", "{EF2F3FF7-51AC-4A8E-A609-869A0D103E18}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.Tests", "test\Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.Tests\Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.Tests.csproj", "{3EBDEDC5-EA1D-4B88-8C06-F74A14E8DB61}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -122,6 +126,14 @@ Global
 		{8324C8D1-A9FD-4F98-8ED9-82C3BE572DBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8324C8D1-A9FD-4F98-8ED9-82C3BE572DBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8324C8D1-A9FD-4F98-8ED9-82C3BE572DBB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EF2F3FF7-51AC-4A8E-A609-869A0D103E18}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EF2F3FF7-51AC-4A8E-A609-869A0D103E18}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EF2F3FF7-51AC-4A8E-A609-869A0D103E18}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EF2F3FF7-51AC-4A8E-A609-869A0D103E18}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3EBDEDC5-EA1D-4B88-8C06-F74A14E8DB61}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3EBDEDC5-EA1D-4B88-8C06-F74A14E8DB61}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3EBDEDC5-EA1D-4B88-8C06-F74A14E8DB61}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3EBDEDC5-EA1D-4B88-8C06-F74A14E8DB61}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -136,6 +148,8 @@ Global
 		{1E7232C2-8560-4030-9B5D-AD88A1680F62} = {66D8DEA8-B477-497F-95BB-E8F9A5BAC352}
 		{A501B346-5613-4EBA-ADC4-88BA38FA322A} = {66D8DEA8-B477-497F-95BB-E8F9A5BAC352}
 		{E2CF25F0-6BD1-459D-8067-E7826D96E8C4} = {66D8DEA8-B477-497F-95BB-E8F9A5BAC352}
+		{EF2F3FF7-51AC-4A8E-A609-869A0D103E18} = {810145E0-41CF-4E24-BD9C-E7517498BA29}
+		{3EBDEDC5-EA1D-4B88-8C06-F74A14E8DB61} = {8B62E3FB-9062-4716-803A-1FA51FCE68BC}
 		{B6C398B2-6F74-4E50-A49F-F36B9825F45E} = {8B62E3FB-9062-4716-803A-1FA51FCE68BC}
 		{AC89B7CF-0FA5-49EE-97A8-AB39A5F211A8} = {8B62E3FB-9062-4716-803A-1FA51FCE68BC}
 		{AEF35BD6-EA9A-4159-86F4-49AF7D17A9A8} = {8B62E3FB-9062-4716-803A-1FA51FCE68BC}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 * [**Integrating OpenAPI-enabled Azure Functions to Azure API Management**](docs/integrate-with-apim.md): This document shows how to integrate the Azure Functions application with [Azure API Management](https://docs.microsoft.com/azure/api-management/api-management-key-concepts?WT.mc_id=dotnet_0000_juyoo), via this OpenAPI extension.
 <!-- * [**Integrating OpenAPI-enabled Azure Functions to Power Platform**](docs/integrate-with-powerplatform.md): This document shows how to integrate the Azure Functions application with [Power Platform](https://powerplatform.microsoft.com/?WT.mc_id=dotnet_0000_juyoo), via this OpenAPI extension. -->
 * [**Generic CI/CD Pipeline Support**](./docs/generic-cicd-pipeline-support.md): This document shows how to generate the OpenAPI document within a CI/CD pipeline, using either PowerShell or bash shell script.
+* [**Build-time OpenAPI Document Generation**](./docs/build-time-openapi-document-generation.md): This document shows how to emit the OpenAPI document at build time for isolated-worker apps - without running the Functions host - using the `Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator` package.
 
 
 ## GitHub Actions Support ##

--- a/docs/build-time-openapi-document-generation.md
+++ b/docs/build-time-openapi-document-generation.md
@@ -1,0 +1,60 @@
+# Build-time OpenAPI Document Generation #
+
+For **isolated-worker** Azure Function Apps you can emit the OpenAPI (`swagger.json`) document at
+**build time**, without running the Functions host. The
+`Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator` package reflects over your built app
+assembly using the **same builder pipeline** as the runtime OpenAPI document endpoint, so the output
+matches what the running app would serve &mdash; but **no host, app settings or network** are
+required. This makes it well-suited to generating API specs deterministically in CI/CD.
+
+> This complements [Generic CI/CD Pipeline Support](./generic-cicd-pipeline-support.md). Use that
+> approach when you need to run the host (for example to honour runtime-resolved settings); use this
+> one for fast, host-less generation as part of `dotnet build`.
+
+
+## Usage ##
+
+Add the package reference. It is a **build-only** dependency &mdash; no runtime dependency is added to
+your app:
+
+```xml
+<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator" Version="1.0.*" PrivateAssets="all" />
+```
+
+On `dotnet build`, `swagger.json` is written next to the built assembly (`$(TargetDir)swagger.json`).
+
+To apply it to **every** Function App in a solution at once, add that line to a shared
+`Directory.Build.props`. Non-Function-App projects (libraries, test projects) are detected and
+skipped, so a blanket reference is safe.
+
+
+## Metadata ##
+
+The generator auto-discovers any class implementing `IOpenApiConfigurationOptions` in your app (the
+same class the runtime endpoint uses) for the title, description and version. If your app registers
+its options *inline in dependency injection* instead of as a class, extract them into a discoverable
+class to get rich metadata &mdash; otherwise a valid document with default metadata is produced.
+
+
+## Requirements ##
+
+* The app must be an isolated-worker Function App (`AzureFunctionsVersion` is set) referencing
+  `Microsoft.Azure.Functions.Worker.Extensions.OpenApi`.
+* A `host.json` must be present in the build output (standard for every Function App).
+
+
+## MSBuild properties ##
+
+| Property | Default | Purpose |
+| --- | --- | --- |
+| `GenerateOpenApiOnBuild` | `true` | Set `false` to disable generation for a project. |
+| `OpenApiOutputPath` | `$(TargetDir)swagger.json` | Where the document is written. |
+| `OpenApiRoutePrefix` | `api` | Route prefix used for the host-agnostic relative `server` URL. |
+
+For example, to write the document to a fixed location:
+
+```xml
+<PropertyGroup>
+  <OpenApiOutputPath>$(MSBuildProjectDirectory)/openapi/swagger.json</OpenApiOutputPath>
+</PropertyGroup>
+```

--- a/docs/generic-cicd-pipeline-support.md
+++ b/docs/generic-cicd-pipeline-support.md
@@ -2,6 +2,8 @@
 
 You can run either PowerShell script or bash shell script to generate the OpenAPI document within your own CI/CD pipeline including Azure DevOps or GitHub Actions.
 
+> For isolated-worker apps, you can also generate the document at build time without running the host. See [Build-time OpenAPI Document Generation](./build-time-openapi-document-generation.md).
+
 
 ## PowerShell ##
 

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator/GeneratorCli.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator/GeneratorCli.cs
@@ -1,0 +1,83 @@
+using System.Reflection;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator;
+
+/// <summary>
+/// Command-line entry point for the build-time OpenAPI generator. Kept as a testable static so the
+/// argument parsing and run flow can be exercised without spawning a process.
+/// </summary>
+public static class GeneratorCli
+{
+    /// <summary>
+    /// Runs the generator.
+    /// Usage: <c>--assembly &lt;path-to-function-app.dll&gt; --output &lt;swagger.json&gt; [--route-prefix api]</c>.
+    /// </summary>
+    /// <param name="args">Command-line arguments.</param>
+    /// <returns>Process exit code (0 on success, 1 on usage/IO error).</returns>
+    public static async Task<int> RunAsync(string[] args)
+    {
+        var parsed = ParseArgs(args);
+
+        if (!parsed.TryGetValue("assembly", out var assemblyPath) || string.IsNullOrWhiteSpace(assemblyPath))
+        {
+            await Console.Error.WriteLineAsync("Missing required --assembly <path>.");
+            return 1;
+        }
+
+        var outputPath = parsed.TryGetValue("output", out var o) && !string.IsNullOrWhiteSpace(o)
+            ? o
+            : "swagger.json";
+        var routePrefix = parsed.TryGetValue("route-prefix", out var rp) && !string.IsNullOrWhiteSpace(rp)
+            ? rp
+            : "api";
+
+        if (!File.Exists(assemblyPath))
+        {
+            await Console.Error.WriteLineAsync($"Assembly not found: {assemblyPath}");
+            return 1;
+        }
+
+        var applicationAssembly = Assembly.LoadFrom(Path.GetFullPath(assemblyPath));
+        var swagger = await OpenApiSpecGenerator.GenerateAsync(applicationAssembly, routePrefix);
+
+        var fullOutputPath = Path.GetFullPath(outputPath);
+        var directory = Path.GetDirectoryName(fullOutputPath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        await File.WriteAllTextAsync(fullOutputPath, swagger);
+        Console.WriteLine($"Wrote OpenAPI document to {fullOutputPath}");
+        return 0;
+    }
+
+    /// <summary>
+    /// Parses <c>--key value</c> / <c>--flag</c> argument pairs into a case-insensitive map.
+    /// </summary>
+    /// <param name="args">Command-line arguments.</param>
+    /// <returns>Parsed key/value pairs.</returns>
+    public static Dictionary<string, string> ParseArgs(string[] args)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < args.Length; i++)
+        {
+            if (!args[i].StartsWith("--", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var key = args[i][2..];
+            if (i + 1 < args.Length && !args[i + 1].StartsWith("--", StringComparison.Ordinal))
+            {
+                result[key] = args[++i];
+            }
+            else
+            {
+                result[key] = "true";
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.csproj
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.csproj
@@ -1,0 +1,55 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\builds\worker.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Target the LTS framework but allow the tool to run on whatever shared runtime the consuming
+         app uses (it is launched via `dotnet exec` against the app's runtimeconfig). -->
+    <RollForward>LatestMajor</RollForward>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Package">
+    <IsPackable>true</IsPackable>
+    <PackageId>Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator</PackageId>
+    <Title>Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator</Title>
+    <Summary>Build-time OpenAPI (swagger.json) generation for isolated-worker Azure Function Apps.</Summary>
+    <Description>Build-time generator that emits an OpenAPI (swagger.json) document for isolated-worker Azure Function Apps by reflecting over the built app assembly using the same pipeline as the runtime OpenAPI endpoint - no Functions host, settings or network required. Add the package reference and the document is produced in the build output automatically.</Description>
+    <PackageTags>Azure-Functions, OpenAPI, Swagger, Swagger-UI, Build, CI</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+
+    <!-- Build-only/dev dependency: ship the tool in tools/ and the MSBuild logic in build/, never a
+         runtime lib/ reference, and don't leak our package dependencies onto consumers. -->
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <!-- Targets-only packages otherwise trip NU5128 (no lib + has dependency group). -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- For the stub IHttpRequestDataObject (HostString / IHeaderDictionary / IQueryCollection).
+         At consumer-build exec time these resolve from the consumer app's dependency closure. -->
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- The OpenAPI builder pipeline, referenced in-repo so the tool is version-locked to this build.
+         Every isolated-worker consumer references this package too, so when the tool runs in the
+         consumer's dependency context the versions align. -->
+    <ProjectReference Include="..\Microsoft.Azure.Functions.Worker.Extensions.OpenApi\Microsoft.Azure.Functions.Worker.Extensions.OpenApi.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Label="Package payload">
+    <!-- The bare tool assembly. Its dependencies are supplied by the consumer at exec time via the
+         consumer's depsfile, so we ship only this dll. -->
+    <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="tools/$(TargetFramework)/" Visible="false" />
+    <None Include="README.md" Pack="true" PackagePath="/" Visible="false" />
+    <None Include="build/**" Pack="true" PackagePath="build/" Visible="false" />
+    <None Include="buildTransitive/**" Pack="true" PackagePath="buildTransitive/" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator/OfflineHttpRequest.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator/OfflineHttpRequest.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator;
+
+/// <summary>
+/// Minimal <see cref="IHttpRequestDataObject"/> so the builder can run without a live Functions host.
+/// <c>AddServer</c> seeds an internal request that <c>Build()</c> dereferences; this stub satisfies that.
+/// </summary>
+internal sealed class OfflineHttpRequest : IHttpRequestDataObject
+{
+    public string Scheme => "https";
+    public HostString Host => new("localhost");
+    public IHeaderDictionary Headers { get; } = new HeaderDictionary();
+    public IQueryCollection Query { get; } = new QueryCollection();
+    public Stream Body { get; } = Stream.Null;
+}

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator/OpenApiSpecGenerator.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator/OpenApiSpecGenerator.cs
@@ -1,0 +1,81 @@
+using System.Reflection;
+
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator;
+
+/// <summary>
+/// Generates an OpenAPI document for an isolated-worker Function App offline, by reflecting over the
+/// app assembly's <c>[OpenApiOperation]</c> functions. The Functions host is never booted - no app
+/// settings and no network access are required. This mirrors the builder pipeline the runtime
+/// OpenAPI document endpoint uses, so the output matches what the running app would serve.
+/// </summary>
+public static class OpenApiSpecGenerator
+{
+    /// <summary>
+    /// Generates the OpenAPI v3 JSON document for the given Function App assembly.
+    /// </summary>
+    /// <param name="applicationAssembly">The built Function App assembly to reflect over.</param>
+    /// <param name="routePrefix">Route prefix used for the host-agnostic relative server URL.</param>
+    /// <returns>The serialised OpenAPI v3 JSON document.</returns>
+    public static async Task<string> GenerateAsync(Assembly applicationAssembly, string routePrefix)
+    {
+        var options = ResolveConfigurationOptions(applicationAssembly);
+
+        // The deployed host is unknown at generation time, so emit a single relative "/{prefix}"
+        // server and disable host-name injection - otherwise AddServer falls back to the stub
+        // request's host and leaks a bogus "localhost" server.
+        options.IncludeRequestingHostName = false;
+        if (options.Servers is null || options.Servers.Count == 0)
+        {
+            options.Servers = [new OpenApiServer { Url = $"/{routePrefix.TrimStart('/')}" }];
+        }
+
+        var context = new OpenApiHttpTriggerContext(options);
+
+        return await context.Document
+            .InitialiseDocument()
+            .AddMetadata(context.OpenApiConfigurationOptions.Info)
+            .AddServer(new OfflineHttpRequest(), routePrefix, context.OpenApiConfigurationOptions)
+            .AddNamingStrategy(context.NamingStrategy)
+            .AddVisitors(context.GetVisitorCollection())
+            .Build(applicationAssembly, OpenApiVersionType.V3)
+            .ApplyDocumentFilters(context.GetDocumentFilterCollection())
+            .RenderAsync(OpenApiSpecVersion.OpenApi3_0, OpenApiFormat.Json);
+    }
+
+    /// <summary>
+    /// Discovers a concrete <see cref="IOpenApiConfigurationOptions"/> in the app assembly (the same
+    /// metadata the runtime endpoint uses), falling back to defaults when the app has none.
+    /// </summary>
+    public static IOpenApiConfigurationOptions ResolveConfigurationOptions(Assembly assembly)
+    {
+        var optionsType = SafeGetTypes(assembly).FirstOrDefault(t =>
+            typeof(IOpenApiConfigurationOptions).IsAssignableFrom(t)
+            && t is { IsAbstract: false, IsInterface: false }
+            && t.GetConstructor(Type.EmptyTypes) is not null);
+
+        if (optionsType is not null)
+        {
+            return (IOpenApiConfigurationOptions)Activator.CreateInstance(optionsType)!;
+        }
+
+        return new DefaultOpenApiConfigurationOptions();
+    }
+
+    private static IEnumerable<Type> SafeGetTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.Where(t => t is not null)!;
+        }
+    }
+}

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator/Program.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator/Program.cs
@@ -1,0 +1,4 @@
+using Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator;
+
+// Usage: --assembly <path-to-function-app.dll> --output <swagger.json> [--route-prefix api]
+return await GeneratorCli.RunAsync(args);

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator/README.md
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator/README.md
@@ -1,0 +1,42 @@
+# Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator
+
+Build-time OpenAPI (`swagger.json`) generation for isolated-worker Azure Function Apps.
+
+It reflects over the built app assembly using the same pipeline as the runtime OpenAPI document
+endpoint &mdash; **no Functions host, app settings or network** are needed. The document is emitted
+into the build output on every build, which makes it ideal for generating API specs in CI.
+
+## Usage
+
+Add the package reference (build-only &mdash; no runtime dependency is added to your app):
+
+```xml
+<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator" Version="1.0.*" PrivateAssets="all" />
+```
+
+To apply it to **every** Function App in a solution at once, add that line to a shared
+`Directory.Build.props`. Non-Function-App projects (libraries, tests) are detected and skipped, so a
+blanket reference is safe.
+
+On `dotnet build`, `swagger.json` is written next to the built assembly (`$(TargetDir)swagger.json`).
+
+### Metadata
+
+The generator auto-discovers any class implementing `IOpenApiConfigurationOptions` in your app (the
+same class the runtime endpoint uses) for the title/description/version. If your app registers its
+options *inline in DI* instead of as a class, extract them into a discoverable class to get rich
+metadata &mdash; otherwise a valid document with default metadata is produced.
+
+### Requirements
+
+- The app must be an isolated-worker Function App (`AzureFunctionsVersion` set) referencing
+  `Microsoft.Azure.Functions.Worker.Extensions.OpenApi`.
+- A `host.json` must be present in the build output (standard for every Function App).
+
+## MSBuild knobs
+
+| Property | Default | Purpose |
+| --- | --- | --- |
+| `GenerateOpenApiOnBuild` | `true` | Set `false` to disable generation for a project. |
+| `OpenApiOutputPath` | `$(TargetDir)swagger.json` | Where the document is written. |
+| `OpenApiRoutePrefix` | `api` | Route prefix used for the host-agnostic relative `server` URL. |

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator/build/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.targets
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator/build/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.targets
@@ -1,0 +1,34 @@
+<Project>
+
+  <PropertyGroup>
+    <!-- Opt-out switch. Defaults on so a bare package reference is enough. -->
+    <GenerateOpenApiOnBuild Condition="'$(GenerateOpenApiOnBuild)' == ''">true</GenerateOpenApiOnBuild>
+    <!-- Where the document is written. Defaults next to the built assembly. -->
+    <OpenApiOutputPath Condition="'$(OpenApiOutputPath)' == ''">$(TargetDir)swagger.json</OpenApiOutputPath>
+    <!-- Route prefix used for the host-agnostic relative server (matches host.json default). -->
+    <OpenApiRoutePrefix Condition="'$(OpenApiRoutePrefix)' == ''">api</OpenApiRoutePrefix>
+    <_OpenApiGeneratorTool>$(MSBuildThisFileDirectory)../tools/net8.0/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.dll</_OpenApiGeneratorTool>
+  </PropertyGroup>
+
+  <!--
+    Generates the OpenAPI document after Build by running the bundled tool inside THIS app's own
+    dependency context (its .deps.json / .runtimeconfig.json), so the app assembly and the OpenAPI
+    extension resolve correctly. Offline: no host, settings or network.
+
+    - Inputs/Outputs make it incremental (only re-runs when the assembly changes).
+    - The AzureFunctionsVersion guard makes it a no-op for non-Function-App projects, so the package
+      can be applied blanket via Directory.Build.props without touching libraries or test projects.
+  -->
+  <Target Name="GenerateOpenApiDocument"
+          AfterTargets="Build"
+          Condition="'$(GenerateOpenApiOnBuild)' == 'true' and '$(AzureFunctionsVersion)' != ''"
+          Inputs="$(TargetPath)"
+          Outputs="$(OpenApiOutputPath)">
+
+    <Message Importance="high" Text="Generating OpenAPI document -> $(OpenApiOutputPath)" />
+
+    <Exec Command="dotnet exec --depsfile &quot;$(TargetDir)$(AssemblyName).deps.json&quot; --runtimeconfig &quot;$(TargetDir)$(AssemblyName).runtimeconfig.json&quot; &quot;$(_OpenApiGeneratorTool)&quot; --assembly &quot;$(TargetPath)&quot; --output &quot;$(OpenApiOutputPath)&quot; --route-prefix &quot;$(OpenApiRoutePrefix)&quot;"
+          WorkingDirectory="$(TargetDir)" />
+  </Target>
+
+</Project>

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator/buildTransitive/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.targets
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator/buildTransitive/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.targets
@@ -1,0 +1,34 @@
+<Project>
+
+  <PropertyGroup>
+    <!-- Opt-out switch. Defaults on so a bare package reference is enough. -->
+    <GenerateOpenApiOnBuild Condition="'$(GenerateOpenApiOnBuild)' == ''">true</GenerateOpenApiOnBuild>
+    <!-- Where the document is written. Defaults next to the built assembly. -->
+    <OpenApiOutputPath Condition="'$(OpenApiOutputPath)' == ''">$(TargetDir)swagger.json</OpenApiOutputPath>
+    <!-- Route prefix used for the host-agnostic relative server (matches host.json default). -->
+    <OpenApiRoutePrefix Condition="'$(OpenApiRoutePrefix)' == ''">api</OpenApiRoutePrefix>
+    <_OpenApiGeneratorTool>$(MSBuildThisFileDirectory)../tools/net8.0/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.dll</_OpenApiGeneratorTool>
+  </PropertyGroup>
+
+  <!--
+    Generates the OpenAPI document after Build by running the bundled tool inside THIS app's own
+    dependency context (its .deps.json / .runtimeconfig.json), so the app assembly and the OpenAPI
+    extension resolve correctly. Offline: no host, settings or network.
+
+    - Inputs/Outputs make it incremental (only re-runs when the assembly changes).
+    - The AzureFunctionsVersion guard makes it a no-op for non-Function-App projects, so the package
+      can be applied blanket via Directory.Build.props without touching libraries or test projects.
+  -->
+  <Target Name="GenerateOpenApiDocument"
+          AfterTargets="Build"
+          Condition="'$(GenerateOpenApiOnBuild)' == 'true' and '$(AzureFunctionsVersion)' != ''"
+          Inputs="$(TargetPath)"
+          Outputs="$(OpenApiOutputPath)">
+
+    <Message Importance="high" Text="Generating OpenAPI document -> $(OpenApiOutputPath)" />
+
+    <Exec Command="dotnet exec --depsfile &quot;$(TargetDir)$(AssemblyName).deps.json&quot; --runtimeconfig &quot;$(TargetDir)$(AssemblyName).runtimeconfig.json&quot; &quot;$(_OpenApiGeneratorTool)&quot; --assembly &quot;$(TargetPath)&quot; --output &quot;$(OpenApiOutputPath)&quot; --route-prefix &quot;$(OpenApiRoutePrefix)&quot;"
+          WorkingDirectory="$(TargetDir)" />
+  </Target>
+
+</Project>

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.Tests/GeneratorCliTests.cs
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.Tests/GeneratorCliTests.cs
@@ -1,0 +1,80 @@
+using System.Reflection;
+
+using FluentAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.Tests;
+
+[TestClass]
+public class GeneratorCliTests
+{
+    private static string SampleAssemblyPath => Path.Combine(
+        AppContext.BaseDirectory,
+        "Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.OutOfProc.dll");
+
+    [TestMethod]
+    public void Given_KeyValue_Args_When_ParseArgs_Then_Maps_Pairs()
+    {
+        var parsed = GeneratorCli.ParseArgs(["--assembly", "app.dll", "--route-prefix", "v1"]);
+
+        parsed["assembly"].Should().Be("app.dll");
+        parsed["route-prefix"].Should().Be("v1");
+    }
+
+    [TestMethod]
+    public void Given_Flag_Without_Value_When_ParseArgs_Then_Sets_True()
+    {
+        var parsed = GeneratorCli.ParseArgs(["--verbose", "--output", "out.json"]);
+
+        parsed["verbose"].Should().Be("true");
+        parsed["output"].Should().Be("out.json");
+    }
+
+    [TestMethod]
+    public void Given_Mixed_Case_Keys_When_ParseArgs_Then_Lookup_Is_Case_Insensitive()
+    {
+        var parsed = GeneratorCli.ParseArgs(["--Assembly", "app.dll"]);
+
+        parsed["assembly"].Should().Be("app.dll");
+    }
+
+    [TestMethod]
+    public async Task Given_No_Assembly_Arg_When_RunAsync_Then_Returns_Error_Code()
+    {
+        var exitCode = await GeneratorCli.RunAsync(["--output", "out.json"]);
+
+        exitCode.Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task Given_Missing_Assembly_File_When_RunAsync_Then_Returns_Error_Code()
+    {
+        var exitCode = await GeneratorCli.RunAsync(["--assembly", "does-not-exist.dll"]);
+
+        exitCode.Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task Given_Valid_Assembly_When_RunAsync_Then_Writes_Document_And_Returns_Zero()
+    {
+        var outputPath = Path.Combine(Path.GetTempPath(), $"swagger-{Guid.NewGuid():N}.json");
+
+        try
+        {
+            var exitCode = await GeneratorCli.RunAsync(
+                ["--assembly", SampleAssemblyPath, "--output", outputPath, "--route-prefix", "api"]);
+
+            exitCode.Should().Be(0);
+            File.Exists(outputPath).Should().BeTrue();
+            (await File.ReadAllTextAsync(outputPath)).Should().Contain("\"openapi\"");
+        }
+        finally
+        {
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.Tests/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.Tests.csproj
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.Tests/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.Tests.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <!-- Only the LTS+ targeting pack is needed to build; roll forward to the installed runtime. -->
+    <RollForward>Major</RollForward>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+
+    <IsPackable>false</IsPackable>
+
+    <AssemblyName>Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.Tests</AssemblyName>
+    <RootNamespace>Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- The tool under test. -->
+    <ProjectReference Include="..\..\src\Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator\Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.csproj" />
+    <!-- A real, attribute-decorated isolated-worker app to generate against. Built and copied to the
+         test output so its assembly can be reflected over via Assembly.LoadFrom. -->
+    <ProjectReference Include="..\..\samples\Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.OutOfProc\Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.OutOfProc.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.Tests/OpenApiSpecGeneratorTests.cs
+++ b/test/Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.Tests/OpenApiSpecGeneratorTests.cs
@@ -1,0 +1,69 @@
+using System.Reflection;
+using System.Text.Json;
+
+using FluentAssertions;
+
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator.Tests;
+
+[TestClass]
+public class OpenApiSpecGeneratorTests
+{
+    // The OutOfProc sample app is built and copied next to the test assembly via ProjectReference.
+    private const string SampleAssemblyName =
+        "Microsoft.Azure.Functions.Worker.Extensions.OpenApi.FunctionApp.OutOfProc.dll";
+
+    private static string SampleAssemblyPath =>
+        Path.Combine(AppContext.BaseDirectory, SampleAssemblyName);
+
+    private static Assembly LoadSampleAssembly() =>
+        Assembly.LoadFrom(SampleAssemblyPath);
+
+    [TestMethod]
+    public async Task Given_SampleApp_When_GenerateAsync_Then_Returns_Valid_OpenApi3_Json()
+    {
+        var json = await OpenApiSpecGenerator.GenerateAsync(LoadSampleAssembly(), "api");
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        root.GetProperty("openapi").GetString().Should().StartWith("3.0");
+        root.GetProperty("info").GetProperty("title").GetString().Should().NotBeNullOrWhiteSpace();
+    }
+
+    [TestMethod]
+    public async Task Given_SampleApp_When_GenerateAsync_Then_Document_Has_Operations()
+    {
+        var json = await OpenApiSpecGenerator.GenerateAsync(LoadSampleAssembly(), "api");
+
+        using var doc = JsonDocument.Parse(json);
+        var paths = doc.RootElement.GetProperty("paths");
+
+        paths.EnumerateObject().Should().NotBeEmpty("the sample app declares [OpenApiOperation] functions");
+    }
+
+    [TestMethod]
+    public async Task Given_RoutePrefix_When_GenerateAsync_Then_Emits_Relative_Server_Without_Host()
+    {
+        var json = await OpenApiSpecGenerator.GenerateAsync(LoadSampleAssembly(), "api");
+
+        using var doc = JsonDocument.Parse(json);
+        var servers = doc.RootElement.GetProperty("servers").EnumerateArray()
+            .Select(s => s.GetProperty("url").GetString())
+            .ToList();
+
+        servers.Should().ContainSingle().Which.Should().Be("/api");
+        servers.Should().NotContain(url => url!.Contains("localhost"));
+    }
+
+    [TestMethod]
+    public void Given_Assembly_Without_Options_When_ResolveConfigurationOptions_Then_Falls_Back_To_Default()
+    {
+        // System.Private.CoreLib contains no IOpenApiConfigurationOptions implementation.
+        var options = OpenApiSpecGenerator.ResolveConfigurationOptions(typeof(string).Assembly);
+
+        options.Should().BeOfType<DefaultOpenApiConfigurationOptions>();
+    }
+}


### PR DESCRIPTION
# Pull request description

> For when/if the maintainer greenlights.
> Base: `Azure/azure-functions-openapi-extension:main` ← `Joeghanoe:feature/build-time-openapi-generator`

---

## What

Adds `Microsoft.Azure.Functions.Worker.Extensions.OpenApi.Generator` — a build-only package that emits `swagger.json` for **isolated-worker** Function Apps at build time, by reflecting over the built app assembly using the **same document builder pipeline as the runtime OpenAPI endpoint**. No Functions host, app settings or network are required, so OpenAPI specs can be generated deterministically in CI.

Addresses #650.

## How it works

- MSBuild targets (`build/` + `buildTransitive/`) run the bundled tool after `Build` via `dotnet exec`, inside the consuming app's own `.deps.json`/`.runtimeconfig.json` context so the app assembly and the OpenAPI extension resolve correctly.
- Incremental (`Inputs`/`Outputs`), and a no-op when `AzureFunctionsVersion` is unset, so a blanket `Directory.Build.props` reference doesn't touch libraries or test projects.
- Auto-discovers the app's `IOpenApiConfigurationOptions` for metadata, falling back to defaults.
- Honours `OpenApi__*` app settings: read from the environment (so CI is automatic), and for local builds the `Values` from a `local.settings.json` next to the assembly are loaded too (like `func start`), without overriding variables already set.

### Knobs

| Property                  | Default                    | Purpose                                                                 |
| ------------------------- | -------------------------- | ----------------------------------------------------------------------- |
| `GenerateOpenApiOnBuild`  | `true`                     | Disable per project                                                     |
| `OpenApiOutputPath`       | `$(TargetDir)swagger.json` | Output location                                                         |
| `OpenApiRoutePrefix`      | `api`                      | Relative `server` URL prefix                                            |
| `OpenApiUseLocalSettings` | `true`                     | Load `OpenApi__*` from `local.settings.json` locally; existing env wins |

## Tests

MSTest + FluentAssertions, generating against the existing OutOfProc sample: valid OpenAPI 3.0.1, populated paths, relative `/api` server (no host leak), options fallback, and CLI handling.

## Verification

- `dotnet build` of the solution: clean (0 errors).
- `dotnet test` on the new project: all green (generates against the OutOfProc sample).
- `dotnet pack`: package contains only `tools/`, `build/` + `buildTransitive/` targets and the README, with no dependency group (nothing leaks onto consumers).
- End-to-end: referencing the packed NuGet from an isolated-worker app and running `dotnet build` emits a valid OpenAPI 3.0.1 `swagger.json` (host-agnostic relative `/api` server) next to the built assembly.
- Parity against the running host (OutOfProc sample): `paths` and `components` are identical to the host-served `/api/swagger.json`; with app settings honoured, `info` matches too. The only by-design differences are the host-agnostic relative `servers` URL and any metadata an app computes in inline DI code (not reflection-discoverable).

## Notes

- New package follows repo conventions (imports `builds/worker.props`: Microsoft authorship, MIT, strong-name signing). Targets `net8.0` for the executable tool.
