### PR TITLE
Migrate Inventory-as-Code ownership from df36aee8-c644-400b-a0ab-fd0f1191211d to e8fdf03b-44f7-48d3-8653-a744c922a342

### DIFF
--- a/es-metadata.yml
+++ b/es-metadata.yml
@@ -1,0 +1,12 @@
+schemaVersion: 1.0.0
+providers:
+- provider: InventoryAsCode
+  version: 1.0.0
+  metadata:
+    isProduction: true
+    accountableOwners:
+      service: e8fdf03b-44f7-48d3-8653-a744c922a342
+    routing:
+      defaultAreaPath:
+        org: azfunc
+        path: internal\Azure Functions


### PR DESCRIPTION
This bootstraps the missing root `es-metadata.yml` for Azure/azure-functions-openapi-extension.

Source: df36aee8-c644-400b-a0ab-fd0f1191211d
Target: e8fdf03b-44f7-48d3-8653-a744c922a342
Routing: internal\Azure Functions

Product Catalog is reassigned immediately.
No auto-merge.

<!-- product-catalog-repo-migrator:df36aee8-c644-400b-a0ab-fd0f1191211d:e8fdf03b-44f7-48d3-8653-a744c922a342 -->